### PR TITLE
bugfix: Autoload errors for `PretrainedModel` on case-sensitive operating systems

### DIFF
--- a/src/Models/Auto/PretrainedMixin.php
+++ b/src/Models/Auto/PretrainedMixin.php
@@ -7,7 +7,7 @@ namespace Codewithkyrian\Transformers\Models\Auto;
 
 use Codewithkyrian\Transformers\Exceptions\UnsupportedModelTypeException;
 use Codewithkyrian\Transformers\Models\ModelArchitecture;
-use Codewithkyrian\Transformers\Models\Pretrained\PreTrainedModel;
+use Codewithkyrian\Transformers\Models\Pretrained\PretrainedModel;
 use Codewithkyrian\Transformers\Utils\AutoConfig;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -38,7 +38,7 @@ abstract class PretrainedMixin
      * @param string|null $cacheDir The cache directory to save the model in.
      * @param string $revision The revision of the model.
      * @param string|null $modelFilename The filename of the model.
-     * @return PreTrainedModel The instantiated pretrained model.
+     * @return PretrainedModel The instantiated pretrained model.
      */
     public static function fromPretrained(
         string  $modelNameOrPath,
@@ -48,7 +48,7 @@ abstract class PretrainedMixin
         string  $revision = 'main',
         ?string $modelFilename = null,
         ?OutputInterface $output = null
-    ): PreTrainedModel
+    ): PretrainedModel
     {
         $config = AutoConfig::fromPretrained($modelNameOrPath, $config, $cacheDir, $revision, $output);
 
@@ -75,7 +75,7 @@ abstract class PretrainedMixin
         if (static::BASE_IF_FAIL) {
             echo "Unknown model class for model type {$config->modelType}. Using base class PreTrainedModel.\n";
 
-            return PreTrainedModel::fromPretrained(
+            return PretrainedModel::fromPretrained(
                 modelNameOrPath: $modelNameOrPath,
                 quantized: $quantized,
                 config: $config,

--- a/src/Models/ModelArchitecture.php
+++ b/src/Models/ModelArchitecture.php
@@ -6,7 +6,7 @@ namespace Codewithkyrian\Transformers\Models;
 
 use Codewithkyrian\Transformers\Exceptions\MissingModelInputException;
 use Codewithkyrian\Transformers\Exceptions\ModelExecutionException;
-use Codewithkyrian\Transformers\Models\Pretrained\PreTrainedModel;
+use Codewithkyrian\Transformers\Models\Pretrained\PretrainedModel;
 use Codewithkyrian\Transformers\Utils\GenerationConfig;
 use Codewithkyrian\Transformers\Utils\Tensor;
 
@@ -30,7 +30,7 @@ enum ModelArchitecture: string
         };
     }
 
-    public function runBeam(PreTrainedModel $model, array &$beam): array
+    public function runBeam(PretrainedModel $model, array &$beam): array
     {
         return match ($this) {
             self::DecoderOnly => $this->decoderRunBeam($model, $beam),
@@ -40,7 +40,7 @@ enum ModelArchitecture: string
     }
 
     public function startBeams(
-        PreTrainedModel  $model,
+        PretrainedModel  $model,
         Tensor           $inputTokenIds,
         GenerationConfig $generationConfig,
         int              $numOutputTokens,
@@ -63,7 +63,7 @@ enum ModelArchitecture: string
         };
     }
 
-    public function forward(PreTrainedModel $model, array $modelInputs): array
+    public function forward(PretrainedModel $model, array $modelInputs): array
     {
         return match ($this) {
             self::EncoderOnly => $this->encoderForward($model, $modelInputs),
@@ -77,7 +77,7 @@ enum ModelArchitecture: string
 
     //<editor-fold desc="Encoder methods">
 
-    protected function encoderForward(PreTrainedModel $model, array $modelInputs): array
+    protected function encoderForward(PretrainedModel $model, array $modelInputs): array
     {
         $encoderFeeds = [];
 
@@ -102,11 +102,11 @@ enum ModelArchitecture: string
 
     /**
      * Runs a single step of the text generation process for a given beam.
-     * @param PreTrainedModel $model The text generation model object.
+     * @param PretrainedModel $model The text generation model object.
      * @param array $beam The beam to run the generation process for.
      * @return array The output of the generation process for the given beam.
      */
-    protected function decoderRunBeam(PreTrainedModel $model, array &$beam): array
+    protected function decoderRunBeam(PretrainedModel $model, array &$beam): array
     {
         $attnMaskLength = count($beam['output_token_ids']);
         $attnMaskData = array_fill(0, $attnMaskLength, 1);
@@ -128,7 +128,7 @@ enum ModelArchitecture: string
     }
 
     /** Starts the generation of text by initializing the beams for the given input token IDs.
-     * @param PreTrainedModel $model The text generation model object.
+     * @param PretrainedModel $model The text generation model object.
      * @param Tensor $inputTokenIds A tensor of input token IDs to generate text from.
      * @param GenerationConfig $generationConfig The generation config.
      * @param int $numOutputTokens The maximum number of tokens to generate for each beam.
@@ -136,7 +136,7 @@ enum ModelArchitecture: string
      * @return array An array of beams initialized with the given inputs and parameters.
      */
     protected function decoderStartBeams(
-        PreTrainedModel  $model,
+        PretrainedModel  $model,
         Tensor           $inputTokenIds,
         GenerationConfig $generationConfig,
         int              $numOutputTokens,
@@ -195,12 +195,12 @@ enum ModelArchitecture: string
 
     /**
      * Forward pass for the decoder model.
-     * @param PreTrainedModel $model The model to use for the forward pass.
+     * @param PretrainedModel $model The model to use for the forward pass.
      * @param array $modelInputs The inputs to the model.
      * @return array The output of the forward pass.
      * @throws MissingModelInputException|ModelExecutionException
      */
-    protected function decoderForward(PreTrainedModel $model, array $modelInputs): array
+    protected function decoderForward(PretrainedModel $model, array $modelInputs): array
     {
         ['input_ids' => $inputIds, 'past_key_values' => $pastKeyValues, 'attention_mask' => $attentionMask]
             = $modelInputs;
@@ -234,7 +234,7 @@ enum ModelArchitecture: string
 
     //<editor-fold desc="Seq2Seq methods">
 
-    protected function seq2seqRunBeam(PreTrainedModel $model, array &$beam): array
+    protected function seq2seqRunBeam(PretrainedModel $model, array &$beam): array
     {
         $inputName = $model->mainInputName;
 
@@ -270,14 +270,14 @@ enum ModelArchitecture: string
     }
 
     /** Start the beam search process for the seq2seq model.
-     * @param PreTrainedModel $model The model to use for the beam search.
+     * @param PretrainedModel $model The model to use for the beam search.
      * @param Tensor $inputTokenIds Array of input token ids for each input sequence.
      * @param GenerationConfig $generationConfig The generation configuration.
      * @param int $numOutputTokens The maximum number of output tokens for the model.
      * @return array Array of beam search objects.
      */
     protected function seq2seqStartBeams(
-        PreTrainedModel  $model,
+        PretrainedModel  $model,
         Tensor           $inputTokenIds,
         GenerationConfig $generationConfig,
         int              $numOutputTokens,
@@ -330,7 +330,7 @@ enum ModelArchitecture: string
         $beam['output_token_ids'][] = $newTokenId;
     }
 
-    protected function seq2seqForward(PreTrainedModel $model, array $modelInputs): array
+    protected function seq2seqForward(PretrainedModel $model, array $modelInputs): array
     {
 
         ['encoder_outputs' => $encoderOutputs, 'past_key_values' => $pastKeyValues] = $modelInputs;

--- a/src/Models/Pretrained/AlbertForMaskedLM.php
+++ b/src/Models/Pretrained/AlbertForMaskedLM.php
@@ -9,7 +9,7 @@ use Codewithkyrian\Transformers\Models\Output\MaskedLMOutput;
 /**
  * AlbertForMaskedLM class for performing masked language modeling on albert models.
  */
-class AlbertForMaskedLM extends BertPreTrainedModel
+class AlbertForMaskedLM extends BertPretrainedModel
 {
     public function __invoke(array $modelInputs): MaskedLMOutput
     {

--- a/src/Models/Pretrained/AlbertForQuestionAnswering.php
+++ b/src/Models/Pretrained/AlbertForQuestionAnswering.php
@@ -10,7 +10,7 @@ use Codewithkyrian\Transformers\Models\Output\SequenceClassifierOutput;
 /**
  * AlbertForQuestionAnswering is a class representing a Albert model for sequence classification.
  */
-class AlbertForQuestionAnswering extends BertPreTrainedModel
+class AlbertForQuestionAnswering extends BertPretrainedModel
 {
     public function __invoke(array $modelInputs): SequenceClassifierOutput
     {

--- a/src/Models/Pretrained/AlbertForSequenceClassification.php
+++ b/src/Models/Pretrained/AlbertForSequenceClassification.php
@@ -10,7 +10,7 @@ use Codewithkyrian\Transformers\Models\Output\SequenceClassifierOutput;
 /**
  * AlbertForSequenceClassification is a class representing a Albert model for sequence classification.
  */
-class AlbertForSequenceClassification extends BertPreTrainedModel
+class AlbertForSequenceClassification extends BertPretrainedModel
 {
     public function __invoke(array $modelInputs): SequenceClassifierOutput
     {

--- a/src/Models/Pretrained/AlbertModel.php
+++ b/src/Models/Pretrained/AlbertModel.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 
 namespace Codewithkyrian\Transformers\Models\Pretrained;
 
-class AlbertModel extends AlbertPreTrainedModel
+class AlbertModel extends AlbertPretrainedModel
 {
 
 }

--- a/src/Models/Pretrained/AlbertPretrainedModel.php
+++ b/src/Models/Pretrained/AlbertPretrainedModel.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 
 namespace Codewithkyrian\Transformers\Models\Pretrained;
 
-class RobertaPreTrainedModel extends PreTrainedModel
+class AlbertPretrainedModel extends PretrainedModel
 {
 
 }

--- a/src/Models/Pretrained/BertForMaskedLM.php
+++ b/src/Models/Pretrained/BertForMaskedLM.php
@@ -9,7 +9,7 @@ use Codewithkyrian\Transformers\Models\Output\MaskedLMOutput;
 /**
  * BertForMaskedLM class for performing masked language modeling on BERT models.
  */
-class BertForMaskedLM extends BertPreTrainedModel
+class BertForMaskedLM extends BertPretrainedModel
 {
     public function __invoke(array $modelInputs): MaskedLMOutput
     {

--- a/src/Models/Pretrained/BertForQuestionAnswering.php
+++ b/src/Models/Pretrained/BertForQuestionAnswering.php
@@ -10,7 +10,7 @@ use Codewithkyrian\Transformers\Models\Output\QuestionAnsweringModelOutput;
 /**
  * BertForQuestionAnswering is a class representing a BERT model for question answering.
  */
-class BertForQuestionAnswering extends BertPreTrainedModel
+class BertForQuestionAnswering extends BertPretrainedModel
 {
     public function __invoke(array $modelInputs): QuestionAnsweringModelOutput
     {

--- a/src/Models/Pretrained/BertForSequenceClassification.php
+++ b/src/Models/Pretrained/BertForSequenceClassification.php
@@ -10,7 +10,7 @@ use Codewithkyrian\Transformers\Models\Output\SequenceClassifierOutput;
 /**
  * BertForSequenceClassification is a class representing a BERT model for sequence classification.
  */
-class BertForSequenceClassification extends BertPreTrainedModel
+class BertForSequenceClassification extends BertPretrainedModel
 {
     public function __invoke(array $modelInputs): SequenceClassifierOutput
     {

--- a/src/Models/Pretrained/BertForTokenClassification.php
+++ b/src/Models/Pretrained/BertForTokenClassification.php
@@ -10,7 +10,7 @@ use Codewithkyrian\Transformers\Models\Output\TokenClassifierOutput;
 /**
  * BertForTokenClassification is a class representing a BERT model for token classification.
  */
-class BertForTokenClassification extends BertPreTrainedModel
+class BertForTokenClassification extends BertPretrainedModel
 {
     public function __invoke(array $modelInputs): TokenClassifierOutput
     {

--- a/src/Models/Pretrained/BertModel.php
+++ b/src/Models/Pretrained/BertModel.php
@@ -5,6 +5,6 @@ declare(strict_types=1);
 
 namespace Codewithkyrian\Transformers\Models\Pretrained;
 
-class BertModel extends BertPreTrainedModel
+class BertModel extends BertPretrainedModel
 {
 }

--- a/src/Models/Pretrained/BertPretrainedModel.php
+++ b/src/Models/Pretrained/BertPretrainedModel.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 
 namespace Codewithkyrian\Transformers\Models\Pretrained;
 
-class DebertaV2PreTrainedModel extends PreTrainedModel
+class BertPretrainedModel extends PretrainedModel
 {
 
 }

--- a/src/Models/Pretrained/CodeGenForCausalLM.php
+++ b/src/Models/Pretrained/CodeGenForCausalLM.php
@@ -8,7 +8,7 @@ namespace Codewithkyrian\Transformers\Models\Pretrained;
 /**
  * CodeGenForCausalLM is a class that represents a code generation model based on the GPT-2 architecture. It extends the `CodeGenPreTrainedModel` class.
  */
-class CodeGenForCausalLM extends CodeGenPreTrainedModel
+class CodeGenForCausalLM extends CodeGenPretrainedModel
 {
 
 }

--- a/src/Models/Pretrained/CodeGenModel.php
+++ b/src/Models/Pretrained/CodeGenModel.php
@@ -8,7 +8,7 @@ namespace Codewithkyrian\Transformers\Models\Pretrained;
 /**
  * CodeGenModel is a class representing a code generation model without a language model head.
  */
-class CodeGenModel extends CodeGenPreTrainedModel
+class CodeGenModel extends CodeGenPretrainedModel
 {
 
 }

--- a/src/Models/Pretrained/CodeGenPretrainedModel.php
+++ b/src/Models/Pretrained/CodeGenPretrainedModel.php
@@ -7,23 +7,22 @@ namespace Codewithkyrian\Transformers\Models\Pretrained;
 
 use Codewithkyrian\Transformers\Models\ModelArchitecture;
 use Codewithkyrian\Transformers\Utils\AutoConfig;
-use Codewithkyrian\Transformers\Utils\GenerationConfig;
 use OnnxRuntime\InferenceSession;
 
-class GPT2PreTrainedModel extends PreTrainedModel
+class CodeGenPretrainedModel extends PretrainedModel
 {
     protected int $numHeads;
     protected int $numLayers;
     protected int $dimKv;
 
     public function __construct(
-        AutoConfig               $config,
-        InferenceSession         $session,
-        public ModelArchitecture $modelArchitecture,
-        public GenerationConfig  $generationConfig
+        AutoConfig        $config,
+        InferenceSession  $session,
+        ModelArchitecture $modelArchitecture = ModelArchitecture::EncoderOnly,
+                          ...$args
     )
     {
-        parent::__construct($config, $session, $modelArchitecture);
+        parent::__construct($config, $session, $modelArchitecture, $args);
 
         // config doesn't contain pad_token_id, so we assume it is the eos_token_id
         $this->config['pad_token_id'] = $this->config['eos_token_id'];
@@ -32,5 +31,6 @@ class GPT2PreTrainedModel extends PreTrainedModel
         $this->numHeads = $this->config['n_head'];
         $this->numLayers = $this->config['n_layer'];
         $this->dimKv = $this->config['n_embd'] / $this->numHeads;
+
     }
 }

--- a/src/Models/Pretrained/DebertaForMaskedLM.php
+++ b/src/Models/Pretrained/DebertaForMaskedLM.php
@@ -9,7 +9,7 @@ use Codewithkyrian\Transformers\Models\Output\MaskedLMOutput;
 /**
  * DebertaForMaskedLM class for performing masked language modeling on DeBERTa models.
  */
-class DebertaForMaskedLM extends DebertaPreTrainedModel
+class DebertaForMaskedLM extends DebertaPretrainedModel
 {
     public function __invoke(array $modelInputs): MaskedLMOutput
     {

--- a/src/Models/Pretrained/DebertaForQuestionAnswering.php
+++ b/src/Models/Pretrained/DebertaForQuestionAnswering.php
@@ -11,7 +11,7 @@ use Codewithkyrian\Transformers\Models\Output\QuestionAnsweringModelOutput;
  * DeBERTa Model with a span classification head on top for extractive question-answering tasks like SQuAD (a linear
  * layers on top of the hidden-states output to compute `span start logits` and `span end logits`).
  */
-class DebertaForQuestionAnswering extends DebertaPreTrainedModel
+class DebertaForQuestionAnswering extends DebertaPretrainedModel
 {
     public function __invoke(array $modelInputs): QuestionAnsweringModelOutput
     {

--- a/src/Models/Pretrained/DebertaForSequenceClassification.php
+++ b/src/Models/Pretrained/DebertaForSequenceClassification.php
@@ -10,7 +10,7 @@ use Codewithkyrian\Transformers\Models\Output\SequenceClassifierOutput;
 /**
  * DebertaForSequenceClassification is a class representing a DeBERTa model for sequence classification.
  */
-class DebertaForSequenceClassification extends DebertaPreTrainedModel
+class DebertaForSequenceClassification extends DebertaPretrainedModel
 {
     public function __invoke(array $modelInputs): SequenceClassifierOutput
     {

--- a/src/Models/Pretrained/DebertaForTokenClassification.php
+++ b/src/Models/Pretrained/DebertaForTokenClassification.php
@@ -10,7 +10,7 @@ use Codewithkyrian\Transformers\Models\Output\TokenClassifierOutput;
 /**
  * DebertaForTokenClassification is a class representing a DeBERTa model for token classification.
  */
-class DebertaForTokenClassification extends DebertaPreTrainedModel
+class DebertaForTokenClassification extends DebertaPretrainedModel
 {
     public function __invoke(array $modelInputs): TokenClassifierOutput
     {

--- a/src/Models/Pretrained/DebertaModel.php
+++ b/src/Models/Pretrained/DebertaModel.php
@@ -8,7 +8,7 @@ namespace Codewithkyrian\Transformers\Models\Pretrained;
 /**
  * The bare DeBERTa Model transformer outputting raw hidden-states without any specific head on top.
  */
-class DebertaModel extends DebertaPreTrainedModel
+class DebertaModel extends DebertaPretrainedModel
 {
 
 }

--- a/src/Models/Pretrained/DebertaPretrainedModel.php
+++ b/src/Models/Pretrained/DebertaPretrainedModel.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 
 namespace Codewithkyrian\Transformers\Models\Pretrained;
 
-class M2M100PreTrainedModel extends PretrainedModel
+class DebertaPretrainedModel extends PretrainedModel
 {
 
 }

--- a/src/Models/Pretrained/DebertaV2ForMaskedLM.php
+++ b/src/Models/Pretrained/DebertaV2ForMaskedLM.php
@@ -9,7 +9,7 @@ use Codewithkyrian\Transformers\Models\Output\MaskedLMOutput;
 /**
  * DeBERTa-V2 Model with a `language modeling` head on top.
  */
-class DebertaV2ForMaskedLM extends DebertaV2PreTrainedModel
+class DebertaV2ForMaskedLM extends DebertaV2PretrainedModel
 {
     public function __invoke(array $modelInputs): MaskedLMOutput
     {

--- a/src/Models/Pretrained/DebertaV2ForQuestionAnswering.php
+++ b/src/Models/Pretrained/DebertaV2ForQuestionAnswering.php
@@ -11,7 +11,7 @@ use Codewithkyrian\Transformers\Models\Output\QuestionAnsweringModelOutput;
  * DeBERTa-V2 Model with a span classification head on top for extractive question-answering tasks like SQuAD (a linear
  * layers on top of the hidden-states output to compute `span start logits` and `span end logits`).
  */
-class DebertaV2ForQuestionAnswering extends DebertaV2PreTrainedModel
+class DebertaV2ForQuestionAnswering extends DebertaV2PretrainedModel
 {
     public function __invoke(array $modelInputs): QuestionAnsweringModelOutput
     {

--- a/src/Models/Pretrained/DebertaV2ForSequenceClassification.php
+++ b/src/Models/Pretrained/DebertaV2ForSequenceClassification.php
@@ -10,7 +10,7 @@ use Codewithkyrian\Transformers\Models\Output\SequenceClassifierOutput;
 /**
  * DeBERTa-V2 Model transformer with a sequence classification/regression head on top (a linear layer on top of the pooled output)
  */
-class DebertaV2ForSequenceClassification extends DebertaV2PreTrainedModel
+class DebertaV2ForSequenceClassification extends DebertaV2PretrainedModel
 {
     public function __invoke(array $modelInputs): SequenceClassifierOutput
     {

--- a/src/Models/Pretrained/DebertaV2ForTokenClassification.php
+++ b/src/Models/Pretrained/DebertaV2ForTokenClassification.php
@@ -10,7 +10,7 @@ use Codewithkyrian\Transformers\Models\Output\TokenClassifierOutput;
 /**
  * DeBERTa-V2 Model with a token classification head on top (a linear layer on top of the hidden-states output) e.g. for Named-Entity-Recognition (NER) tasks.
  */
-class DebertaV2ForTokenClassification extends DebertaV2PreTrainedModel
+class DebertaV2ForTokenClassification extends DebertaV2PretrainedModel
 {
     public function __invoke(array $modelInputs): TokenClassifierOutput
     {

--- a/src/Models/Pretrained/DebertaV2Model.php
+++ b/src/Models/Pretrained/DebertaV2Model.php
@@ -8,7 +8,7 @@ namespace Codewithkyrian\Transformers\Models\Pretrained;
 /**
  * The bare DeBERTa-V2 Model transformer outputting raw hidden-states without any specific head on top.
  */
-class DebertaV2Model extends DebertaV2PreTrainedModel
+class DebertaV2Model extends DebertaV2PretrainedModel
 {
 
 }

--- a/src/Models/Pretrained/DebertaV2PretrainedModel.php
+++ b/src/Models/Pretrained/DebertaV2PretrainedModel.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 
 namespace Codewithkyrian\Transformers\Models\Pretrained;
 
-class AlbertPreTrainedModel extends PreTrainedModel
+class DebertaV2PretrainedModel extends PretrainedModel
 {
 
 }

--- a/src/Models/Pretrained/DistilBertForMaskedLM.php
+++ b/src/Models/Pretrained/DistilBertForMaskedLM.php
@@ -9,7 +9,7 @@ use Codewithkyrian\Transformers\Models\Output\MaskedLMOutput;
 /**
  * DistilBertForMaskedLM class for performing masked language modeling on DistilBERT models.
  */
-class DistilBertForMaskedLM extends RobertaPreTrainedModel
+class DistilBertForMaskedLM extends RobertaPretrainedModel
 {
     public function __invoke(array $modelInputs): MaskedLMOutput
     {

--- a/src/Models/Pretrained/DistilBertForQuestionAnswering.php
+++ b/src/Models/Pretrained/DistilBertForQuestionAnswering.php
@@ -10,7 +10,7 @@ use Codewithkyrian\Transformers\Models\Output\QuestionAnsweringModelOutput;
 /**
  * DistilBertForQuestionAnswering is a class representing a DistilBERT model for question answering.
  */
-class DistilBertForQuestionAnswering extends BertPreTrainedModel
+class DistilBertForQuestionAnswering extends BertPretrainedModel
 {
     public function __invoke(array $modelInputs): QuestionAnsweringModelOutput
     {

--- a/src/Models/Pretrained/GPT2LMHeadModel.php
+++ b/src/Models/Pretrained/GPT2LMHeadModel.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 
 namespace Codewithkyrian\Transformers\Models\Pretrained;
 
-class GPT2LMHeadModel extends GPT2PreTrainedModel
+class GPT2LMHeadModel extends GPT2PretrainedModel
 {
 
 }

--- a/src/Models/Pretrained/GPT2Model.php
+++ b/src/Models/Pretrained/GPT2Model.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 
 namespace Codewithkyrian\Transformers\Models\Pretrained;
 
-class GPT2Model extends GPT2PreTrainedModel
+class GPT2Model extends GPT2PretrainedModel
 {
 
 }

--- a/src/Models/Pretrained/GPT2PretrainedModel.php
+++ b/src/Models/Pretrained/GPT2PretrainedModel.php
@@ -7,22 +7,23 @@ namespace Codewithkyrian\Transformers\Models\Pretrained;
 
 use Codewithkyrian\Transformers\Models\ModelArchitecture;
 use Codewithkyrian\Transformers\Utils\AutoConfig;
+use Codewithkyrian\Transformers\Utils\GenerationConfig;
 use OnnxRuntime\InferenceSession;
 
-class CodeGenPreTrainedModel extends PretrainedModel
+class GPT2PretrainedModel extends PretrainedModel
 {
     protected int $numHeads;
     protected int $numLayers;
     protected int $dimKv;
 
     public function __construct(
-        AutoConfig        $config,
-        InferenceSession  $session,
-        ModelArchitecture $modelArchitecture = ModelArchitecture::EncoderOnly,
-                          ...$args
+        AutoConfig               $config,
+        InferenceSession         $session,
+        public ModelArchitecture $modelArchitecture,
+        public GenerationConfig  $generationConfig
     )
     {
-        parent::__construct($config, $session, $modelArchitecture, $args);
+        parent::__construct($config, $session, $modelArchitecture);
 
         // config doesn't contain pad_token_id, so we assume it is the eos_token_id
         $this->config['pad_token_id'] = $this->config['eos_token_id'];
@@ -31,6 +32,5 @@ class CodeGenPreTrainedModel extends PretrainedModel
         $this->numHeads = $this->config['n_head'];
         $this->numLayers = $this->config['n_layer'];
         $this->dimKv = $this->config['n_embd'] / $this->numHeads;
-
     }
 }

--- a/src/Models/Pretrained/GPTBigCodeForCausalLM.php
+++ b/src/Models/Pretrained/GPTBigCodeForCausalLM.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 
 namespace Codewithkyrian\Transformers\Models\Pretrained;
 
-class GPTBigCodeForCausalLM extends GPTBigCodePreTrainedModel
+class GPTBigCodeForCausalLM extends GPTBigCodePretrainedModel
 {
 
 }

--- a/src/Models/Pretrained/GPTBigCodeModel.php
+++ b/src/Models/Pretrained/GPTBigCodeModel.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 
 namespace Codewithkyrian\Transformers\Models\Pretrained;
 
-class GPTBigCodeModel extends GPTBigCodePreTrainedModel
+class GPTBigCodeModel extends GPTBigCodePretrainedModel
 {
 
 }

--- a/src/Models/Pretrained/GPTBigCodePretrainedModel.php
+++ b/src/Models/Pretrained/GPTBigCodePretrainedModel.php
@@ -10,7 +10,7 @@ use Codewithkyrian\Transformers\Utils\AutoConfig;
 use Codewithkyrian\Transformers\Utils\GenerationConfig;
 use OnnxRuntime\InferenceSession;
 
-class GPTBigCodePreTrainedModel extends PreTrainedModel
+class GPTBigCodePretrainedModel extends PretrainedModel
 {
     protected int $numHeads;
     protected int $numLayers;

--- a/src/Models/Pretrained/GPTJForCausalLM.php
+++ b/src/Models/Pretrained/GPTJForCausalLM.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 
 namespace Codewithkyrian\Transformers\Models\Pretrained;
 
-class GPTJForCausalLM extends GPTJPreTrainedModel
+class GPTJForCausalLM extends GPTJPretrainedModel
 {
 
 }

--- a/src/Models/Pretrained/GPTJModel.php
+++ b/src/Models/Pretrained/GPTJModel.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 
 namespace Codewithkyrian\Transformers\Models\Pretrained;
 
-class GPTJModel extends GPTJPreTrainedModel
+class GPTJModel extends GPTJPretrainedModel
 {
 
 }

--- a/src/Models/Pretrained/GPTJPretrainedModel.php
+++ b/src/Models/Pretrained/GPTJPretrainedModel.php
@@ -9,7 +9,7 @@ use Codewithkyrian\Transformers\Models\ModelArchitecture;
 use Codewithkyrian\Transformers\Utils\AutoConfig;
 use OnnxRuntime\InferenceSession;
 
-class GPTJPreTrainedModel extends PretrainedModel
+class GPTJPretrainedModel extends PretrainedModel
 {
     protected int $numHeads;
     protected int $numLayers;

--- a/src/Models/Pretrained/M2M100ForConditionalGeneration.php
+++ b/src/Models/Pretrained/M2M100ForConditionalGeneration.php
@@ -10,7 +10,7 @@ use Codewithkyrian\Transformers\Utils\AutoConfig;
 use Codewithkyrian\Transformers\Utils\GenerationConfig;
 use OnnxRuntime\InferenceSession;
 
-class M2M100ForConditionalGeneration extends M2M100PreTrainedModel
+class M2M100ForConditionalGeneration extends M2M100PretrainedModel
 {
     protected mixed $numDecoderLayers;
     protected mixed $numDecoderHeads;

--- a/src/Models/Pretrained/M2M100Model.php
+++ b/src/Models/Pretrained/M2M100Model.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 
 namespace Codewithkyrian\Transformers\Models\Pretrained;
 
-class M2M100Model extends M2M100PreTrainedModel
+class M2M100Model extends M2M100PretrainedModel
 {
 
 }

--- a/src/Models/Pretrained/M2M100PretrainedModel.php
+++ b/src/Models/Pretrained/M2M100PretrainedModel.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 
 namespace Codewithkyrian\Transformers\Models\Pretrained;
 
-class RoFormerPreTrainedModel extends PreTrainedModel
+class M2M100PretrainedModel extends PretrainedModel
 {
 
 }

--- a/src/Models/Pretrained/MobileBertForMaskedLM.php
+++ b/src/Models/Pretrained/MobileBertForMaskedLM.php
@@ -9,7 +9,7 @@ use Codewithkyrian\Transformers\Models\Output\MaskedLMOutput;
 /**
  * MobileBertForMaskedLM is a class representing a MobileBERT model for masking task.
  */
-class MobileBertForMaskedLM extends MobileBertPreTrainedModel
+class MobileBertForMaskedLM extends MobileBertPretrainedModel
 {
     public function __invoke(array $modelInputs): MaskedLMOutput
     {

--- a/src/Models/Pretrained/MobileBertForQuestionAnswering.php
+++ b/src/Models/Pretrained/MobileBertForQuestionAnswering.php
@@ -10,7 +10,7 @@ use Codewithkyrian\Transformers\Models\Output\QuestionAnsweringModelOutput;
 /**
  * MobileBert Model with a span classification head on top for extractive question-answering tasks
  */
-class MobileBertForQuestionAnswering extends MobileBertPreTrainedModel
+class MobileBertForQuestionAnswering extends MobileBertPretrainedModel
 {
     public function __invoke(array $modelInputs): QuestionAnsweringModelOutput
     {

--- a/src/Models/Pretrained/MobileBertForSequenceClassification.php
+++ b/src/Models/Pretrained/MobileBertForSequenceClassification.php
@@ -10,7 +10,7 @@ use Codewithkyrian\Transformers\Models\Output\SequenceClassifierOutput;
 /**
  * MobileBert Model transformer with a sequence classification/regression head on top (a linear layer on top of the pooled output)
  */
-class MobileBertForSequenceClassification extends MobileBertPreTrainedModel
+class MobileBertForSequenceClassification extends MobileBertPretrainedModel
 {
     public function __invoke(array $modelInputs): SequenceClassifierOutput
     {

--- a/src/Models/Pretrained/MobileBertModel.php
+++ b/src/Models/Pretrained/MobileBertModel.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 
 namespace Codewithkyrian\Transformers\Models\Pretrained;
 
-class MobileBertModel extends MobileBertPreTrainedModel
+class MobileBertModel extends MobileBertPretrainedModel
 {
 
 }

--- a/src/Models/Pretrained/MobileBertPretrainedModel.php
+++ b/src/Models/Pretrained/MobileBertPretrainedModel.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 
 namespace Codewithkyrian\Transformers\Models\Pretrained;
 
-class T5PreTrainedModel extends PretrainedModel
+class MobileBertPretrainedModel extends PretrainedModel
 {
 
 }

--- a/src/Models/Pretrained/PretrainedModel.php
+++ b/src/Models/Pretrained/PretrainedModel.php
@@ -37,7 +37,7 @@ use function Codewithkyrian\Transformers\Utils\array_some;
 /**
  * A base class for pre-trained models that provides the model configuration and an ONNX session.
  */
-class PreTrainedModel
+class PretrainedModel
 {
     public string $mainInputName = 'input_ids';
 

--- a/src/Models/Pretrained/RoFormerForMaskedLM.php
+++ b/src/Models/Pretrained/RoFormerForMaskedLM.php
@@ -9,7 +9,7 @@ use Codewithkyrian\Transformers\Models\Output\MaskedLMOutput;
 /**
  * RoFormer Model with a `language modeling` head on top.
  */
-class RoFormerForMaskedLM extends RoFormerPreTrainedModel
+class RoFormerForMaskedLM extends RoFormerPretrainedModel
 {
     public function __invoke(array $modelInputs): MaskedLMOutput
     {

--- a/src/Models/Pretrained/RoFormerForQuestionAnswering.php
+++ b/src/Models/Pretrained/RoFormerForQuestionAnswering.php
@@ -11,7 +11,7 @@ use Codewithkyrian\Transformers\Models\Output\QuestionAnsweringModelOutput;
  * RoFormer Model with a span classification head on top for extractive question-answering tasks like SQuAD
  * (a linear layers on top of the hidden-states output to compute `span start logits` and `span end logits`).
  */
-class RoFormerForQuestionAnswering extends RobertaPreTrainedModel
+class RoFormerForQuestionAnswering extends RobertaPretrainedModel
 {
     public function __invoke(array $modelInputs): QuestionAnsweringModelOutput
     {

--- a/src/Models/Pretrained/RoFormerForSequenceClassification.php
+++ b/src/Models/Pretrained/RoFormerForSequenceClassification.php
@@ -10,7 +10,7 @@ use Codewithkyrian\Transformers\Models\Output\SequenceClassifierOutput;
 /**
  * RoFormer Model transformer with a sequence classification/regression head on top (a linear layer on top of the pooled output)
  */
-class RoFormerForSequenceClassification extends RoFormerPreTrainedModel
+class RoFormerForSequenceClassification extends RoFormerPretrainedModel
 {
     public function __invoke(array $modelInputs): SequenceClassifierOutput
     {

--- a/src/Models/Pretrained/RoFormerForTokenClassification.php
+++ b/src/Models/Pretrained/RoFormerForTokenClassification.php
@@ -12,7 +12,7 @@ use Codewithkyrian\Transformers\Models\Output\TokenClassifierOutput;
  * RoFormer Model with a token classification head on top (a linear layer on top of the hidden-states output)
  * e.g. for Named-Entity-Recognition (NER) tasks.
  */
-class RoFormerForTokenClassification extends RobertaPreTrainedModel
+class RoFormerForTokenClassification extends RobertaPretrainedModel
 {
     public function __invoke(array $modelInputs): TokenClassifierOutput
     {

--- a/src/Models/Pretrained/RoFormerModel.php
+++ b/src/Models/Pretrained/RoFormerModel.php
@@ -8,7 +8,7 @@ namespace Codewithkyrian\Transformers\Models\Pretrained;
 /**
  * The bare RoFormer Model transformer outputting raw hidden-states without any specific head on top.
  */
-class RoFormerModel extends RoFormerPreTrainedModel
+class RoFormerModel extends RoFormerPretrainedModel
 {
 
 }

--- a/src/Models/Pretrained/RoFormerPretrainedModel.php
+++ b/src/Models/Pretrained/RoFormerPretrainedModel.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 
 namespace Codewithkyrian\Transformers\Models\Pretrained;
 
-class MobileBertPreTrainedModel extends PreTrainedModel
+class RoFormerPretrainedModel extends PretrainedModel
 {
 
 }

--- a/src/Models/Pretrained/RobertaForMaskedLM.php
+++ b/src/Models/Pretrained/RobertaForMaskedLM.php
@@ -9,7 +9,7 @@ use Codewithkyrian\Transformers\Models\Output\MaskedLMOutput;
 /**
  * RobertaForMaskedLM class for performing masked language modeling on Roberta models.
  */
-class RobertaForMaskedLM extends RobertaPreTrainedModel
+class RobertaForMaskedLM extends RobertaPretrainedModel
 {
     public function __invoke(array $modelInputs): MaskedLMOutput
     {

--- a/src/Models/Pretrained/RobertaForQuestionAnswering.php
+++ b/src/Models/Pretrained/RobertaForQuestionAnswering.php
@@ -10,7 +10,7 @@ use Codewithkyrian\Transformers\Models\Output\QuestionAnsweringModelOutput;
 /**
  * RobertaForQuestionAnswering class for performing question answering on Roberta models.
  */
-class RobertaForQuestionAnswering extends RobertaPreTrainedModel
+class RobertaForQuestionAnswering extends RobertaPretrainedModel
 {
     public function __invoke(array $modelInputs): QuestionAnsweringModelOutput
     {

--- a/src/Models/Pretrained/RobertaForSequenceClassification.php
+++ b/src/Models/Pretrained/RobertaForSequenceClassification.php
@@ -10,7 +10,7 @@ use Codewithkyrian\Transformers\Models\Output\SequenceClassifierOutput;
 /**
  * RobertaForSequenceClassification class for performing sequence classification on Roberta models.
  */
-class RobertaForSequenceClassification extends RobertaPreTrainedModel
+class RobertaForSequenceClassification extends RobertaPretrainedModel
 {
     public function __invoke(array $modelInputs): SequenceClassifierOutput
     {

--- a/src/Models/Pretrained/RobertaForTokenClassification.php
+++ b/src/Models/Pretrained/RobertaForTokenClassification.php
@@ -11,7 +11,7 @@ use Codewithkyrian\Transformers\Models\Output\TokenClassifierOutput;
 /**
  * RobertaForTokenClassification class for performing token classification on Roberta models.
  */
-class RobertaForTokenClassification extends RobertaPreTrainedModel
+class RobertaForTokenClassification extends RobertaPretrainedModel
 {
     public function __invoke(array $modelInputs): TokenClassifierOutput
     {

--- a/src/Models/Pretrained/RobertaModel.php
+++ b/src/Models/Pretrained/RobertaModel.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 
 namespace Codewithkyrian\Transformers\Models\Pretrained;
 
-class RobertaModel extends RobertaPreTrainedModel
+class RobertaModel extends RobertaPretrainedModel
 {
 
 }

--- a/src/Models/Pretrained/RobertaPretrainedModel.php
+++ b/src/Models/Pretrained/RobertaPretrainedModel.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 
 namespace Codewithkyrian\Transformers\Models\Pretrained;
 
-class DebertaPreTrainedModel extends PreTrainedModel
+class RobertaPretrainedModel extends PretrainedModel
 {
 
 }

--- a/src/Models/Pretrained/T5ForConditionalGeneration.php
+++ b/src/Models/Pretrained/T5ForConditionalGeneration.php
@@ -13,7 +13,7 @@ use OnnxRuntime\InferenceSession;
 /**
  * T5Model is a class representing a T5 model for conditional generation.
  */
-class T5ForConditionalGeneration extends T5PreTrainedModel
+class T5ForConditionalGeneration extends T5PretrainedModel
 {
     protected mixed $numDecoderLayers;
     protected mixed $numDecoderHeads;

--- a/src/Models/Pretrained/T5Model.php
+++ b/src/Models/Pretrained/T5Model.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 
 namespace Codewithkyrian\Transformers\Models\Pretrained;
 
-class T5Model extends T5PreTrainedModel
+class T5Model extends T5PretrainedModel
 {
 
 }

--- a/src/Models/Pretrained/T5PretrainedModel.php
+++ b/src/Models/Pretrained/T5PretrainedModel.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 
 namespace Codewithkyrian\Transformers\Models\Pretrained;
 
-class BertPreTrainedModel extends PretrainedModel
+class T5PretrainedModel extends PretrainedModel
 {
 
 }

--- a/src/Pipelines/Pipeline.php
+++ b/src/Pipelines/Pipeline.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Codewithkyrian\Transformers\Pipelines;
 
 use Codewithkyrian\Transformers\Exceptions\UnsupportedTaskException;
-use Codewithkyrian\Transformers\Models\Pretrained\PreTrainedModel;
+use Codewithkyrian\Transformers\Models\Pretrained\PretrainedModel;
 use Codewithkyrian\Transformers\PretrainedTokenizers\AutoTokenizer;
 use Codewithkyrian\Transformers\PretrainedTokenizers\PretrainedTokenizer;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -14,7 +14,7 @@ class Pipeline
 {
     public function __construct(
         protected string|Task       $task,
-        protected PreTrainedModel   $model,
+        protected PretrainedModel   $model,
         public ?PretrainedTokenizer $tokenizer = null,
         protected ?string           $processor = null,
     )

--- a/src/Pipelines/Task.php
+++ b/src/Pipelines/Task.php
@@ -11,7 +11,7 @@ use Codewithkyrian\Transformers\Models\Auto\AutoModelForQuestionAnswering;
 use Codewithkyrian\Transformers\Models\Auto\AutoModelForSeq2SeqLM;
 use Codewithkyrian\Transformers\Models\Auto\AutoModelForSequenceClassification;
 use Codewithkyrian\Transformers\Models\Auto\AutoModelForTokenClassification;
-use Codewithkyrian\Transformers\Models\Pretrained\PreTrainedModel;
+use Codewithkyrian\Transformers\Models\Pretrained\PretrainedModel;
 use Codewithkyrian\Transformers\PretrainedTokenizers\PretrainedTokenizer;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -31,7 +31,7 @@ enum Task: string
     case TokenClassification = 'token-classification';
     case Ner = 'ner';
 
-    public function getPipeline(PreTrainedModel $model, PretrainedTokenizer $tokenizer): Pipeline
+    public function getPipeline(PretrainedModel $model, PretrainedTokenizer $tokenizer): Pipeline
     {
         return match ($this) {
             self::SentimentAnalysis,
@@ -93,7 +93,7 @@ enum Task: string
         string           $revision = 'main',
         ?string          $modelFilename = null,
         ?OutputInterface $output = null
-    ): PreTrainedModel
+    ): PretrainedModel
     {
         return match ($this) {
             self::SentimentAnalysis,

--- a/src/Pipelines/ZeroShotClassificationPipeline.php
+++ b/src/Pipelines/ZeroShotClassificationPipeline.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
 namespace Codewithkyrian\Transformers\Pipelines;
 
 use Codewithkyrian\Transformers\Models\Output\SequenceClassifierOutput;
-use Codewithkyrian\Transformers\Models\Pretrained\PreTrainedModel;
+use Codewithkyrian\Transformers\Models\Pretrained\PretrainedModel;
 use Codewithkyrian\Transformers\PretrainedTokenizers\PretrainedTokenizer;
 use Codewithkyrian\Transformers\Utils\Math;
 
@@ -58,7 +58,7 @@ class ZeroShotClassificationPipeline extends Pipeline
 
     protected mixed $contradictionId;
 
-    public function __construct(Task|string $task, PreTrainedModel $model, ?PretrainedTokenizer $tokenizer = null, ?string $processor = null)
+    public function __construct(Task|string $task, PretrainedModel $model, ?PretrainedTokenizer $tokenizer = null, ?string $processor = null)
     {
         parent::__construct($task, $model, $tokenizer, $processor);
 


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

- Renamed class "PreTrainedModel" to "PretrainedModel" for consistency.
- Updated and renamed affected child classes.


### Related:

- https://github.com/CodeWithKyrian/transformers-php/issues/3
