### PR TITLE
Add symfony/console explicitly as a dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
     "php": "^8.1",
     "guzzlehttp/guzzle": "^7.0",
     "ankane/onnxruntime": "^0.2.0",
-    "ext-gd": "*",
     "rindow/rindow-math-matrix": "^1.2",
     "spatie/fork": "^1.2",
-    "codewithkyrian/jinja-php": "^1.0"
+    "codewithkyrian/jinja-php": "^1.0",
+    "symfony/console": "^6.4|^7.0"
   },
   "require-dev": {
     "pestphp/pest": "^2.31",


### PR DESCRIPTION
### What:

- [x] Bug Fix

### Description:

Explicitly adds Symfony Console as a runtime depedency
