### PR TITLE
bugfix: https slashes affected when joining paths

### DIFF
--- a/src/Utils/Helpers.php
+++ b/src/Utils/Helpers.php
@@ -81,7 +81,7 @@ function joinPaths(string ...$args): string
         }
     }
 
-    return preg_replace('#/+#', '/', implode(DIRECTORY_SEPARATOR, $paths));
+    return preg_replace('#(?<!:)//+#', '/', implode(DIRECTORY_SEPARATOR, $paths));
 }
 
 function ensureDirectory($filePath): void


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

This PR fixes the joinPaths method that previously doesn't handle the double slash for remote urls properly. 

### Related:

- https://github.com/CodeWithKyrian/transformers-php/issues/18
