### PR TITLE
Add chat input detection for text generation, and refactor streamer API.

### DIFF
--- a/examples/pipelines/summarization.php
+++ b/examples/pipelines/summarization.php
@@ -14,7 +14,7 @@ ini_set('memory_limit', -1);
 
 $summarizer = pipeline('summarization', 'Xenova/distilbart-cnn-6-6');
 
-$streamer = StdOutStreamer::make($summarizer->tokenizer);
+$streamer = StdOutStreamer::make();
 
 $article = 'The tower is 324 metres (1,063 ft) tall, about the same height as an 81-storey building, ' .
     'and the tallest structure in Paris. Its base is square, measuring 125 metres (410 ft) on each side. ' .
@@ -29,6 +29,6 @@ $article = 'The tower is 324 metres (1,063 ft) tall, about the same height as an
 //$article = "I called my friend to see if he wanted to go to the movies. However, he was busy and said he would " .
 //    "call me back. I didn't hear back from him, so I called him again. He didn't answer, so I decided to go to the movies by myself.";
 
-$summary = $summarizer($article, streamer: $streamer,  maxNewTokens: 512, temperature: 0.7);
+$summary = $summarizer($article, streamer: $streamer, maxNewTokens: 512, temperature: 0.7);
 
 dd("Done", timeUsage(), memoryUsage());

--- a/examples/pipelines/text-generation.php
+++ b/examples/pipelines/text-generation.php
@@ -14,19 +14,20 @@ ini_set('memory_limit', -1);
 //$generator = pipeline('text-generation', 'Xenova/gpt2');
 $generator = pipeline('text-generation', 'Xenova/Qwen1.5-0.5B-Chat');
 
-$streamer = StdOutStreamer::make($generator->tokenizer);
+$streamer = StdOutStreamer::make();
 
 $messages = [
     ['role' => 'system', 'content' => 'You are a helpful assistant.'],
-    ['role' => 'user', 'content' => 'Who are you'],
+    ['role' => 'user', 'content' => 'What is the product of 5 and 4'],
 ];
 
 $input = $generator->tokenizer->applyChatTemplate($messages, addGenerationPrompt: true, tokenize: false);
 
-$output = $generator($messages,
+$output = $generator($input,
     streamer: $streamer,
     maxNewTokens: 128,
     doSample: true,
+    returnFullText: false,
 //    temperature: 0.7,
 //    repetitionPenalty: 1.3,
 //    earlyStopping: true
@@ -42,4 +43,4 @@ $output = $generator($messages,
 //    doSample: true
 //);
 
-dd("done", timeUsage(), memoryUsage());
+dd($output[0]['generated_text'], timeUsage(), memoryUsage());

--- a/examples/pipelines/text2text-generation.php
+++ b/examples/pipelines/text2text-generation.php
@@ -12,7 +12,7 @@ ini_set('memory_limit', -1);
 $generator = pipeline('text2text-generation', 'Xenova/LaMini-Flan-T5-783M');
 //$generator = pipeline('text2text-generation', 'Xenova/flan-t5-small', quantized: true);
 
-$streamer = StdOutStreamer::make($generator->tokenizer);
+$streamer = StdOutStreamer::make();
 
 //$query = 'Please let me know your thoughts on the given place and why you think it deserves to be visited: \n" Barcelona, Spain"';
 $query = 'How many continents are in the world? List them out';

--- a/examples/pipelines/translation.php
+++ b/examples/pipelines/translation.php
@@ -13,10 +13,10 @@ ini_set('memory_limit', -1);
 
 $translator = pipeline('translation', 'Xenova/m2m100_418M');
 
-$streamer = StdOutStreamer::make($translator->tokenizer);
+$streamer = StdOutStreamer::make();
 
-$output = $translator('生活就像一盒巧克力。', streamer: $streamer, tgtLang: 'en');
+//$output = $translator('生活就像一盒巧克力。', streamer: $streamer, tgtLang: 'en');
 //$output = $translator('जीवन एक चॉकलेट बॉक्स की तरह है।', streamer: $streamer, tgtLang: 'fr');
-//$output = $translator('संयुक्त राष्ट्र के प्रमुख का कहना है कि सीरिया में कोई सैन्य समाधान नहीं है', streamer: $streamer, tgtLang: 'fr', maxNewTokens: 256);
+$output = $translator('संयुक्त राष्ट्र के प्रमुख का कहना है कि सीरिया में कोई सैन्य समाधान नहीं है', streamer: $streamer, tgtLang: 'fr', maxNewTokens: 256);
 
 dd("done", timeUsage(), memoryUsage());

--- a/src/Generation/Streamers/StdOutStreamer.php
+++ b/src/Generation/Streamers/StdOutStreamer.php
@@ -5,18 +5,16 @@ declare(strict_types=1);
 
 namespace Codewithkyrian\Transformers\Generation\Streamers;
 
-use Codewithkyrian\Transformers\PretrainedTokenizers\PretrainedTokenizer;
-
 class StdOutStreamer extends TextStreamer
 {
-    public function __construct(PretrainedTokenizer $tokenizer, StreamMode $streamMode = StreamMode::PARTIAL)
+    public function __construct(StreamMode $streamMode = StreamMode::PARTIAL)
     {
-        parent::__construct($tokenizer);
+        parent::__construct();
+
         $this->setStreamMode($streamMode);
-        if($streamMode === StreamMode::FULL) {
+        if ($streamMode === StreamMode::FULL) {
             $this->onStreamEnd(fn(string $full) => $this->echoToConsole($full, true));
-        }
-        else {
+        } else {
             $this->onStream(fn(string $partial) => $this->echoToConsole($partial));
             $this->onStreamEnd(fn(string $full) => $this->echoToConsole('', true));
         }

--- a/src/Generation/Streamers/Streamer.php
+++ b/src/Generation/Streamers/Streamer.php
@@ -5,11 +5,15 @@ declare(strict_types=1);
 
 namespace Codewithkyrian\Transformers\Generation\Streamers;
 
+use Codewithkyrian\Transformers\PretrainedTokenizers\PretrainedTokenizer;
+
 /**
  * Base streamer from which all streamers inherit.
  */
 abstract class Streamer
 {
+    abstract public function init(PretrainedTokenizer $tokenizer, array $inputTokens, bool $includeInput): void;
+
     abstract public function put(mixed $value): void;
 
     abstract public function end(): void;

--- a/src/Generation/Streamers/Streamer.php
+++ b/src/Generation/Streamers/Streamer.php
@@ -12,7 +12,7 @@ use Codewithkyrian\Transformers\PretrainedTokenizers\PretrainedTokenizer;
  */
 abstract class Streamer
 {
-    abstract public function init(PretrainedTokenizer $tokenizer, array $inputTokens, bool $includeInput): void;
+    abstract public function init(PretrainedTokenizer $tokenizer, array $inputTokens, bool $excludeInput = false): void;
 
     abstract public function put(mixed $value): void;
 

--- a/src/Generation/Streamers/TextStreamer.php
+++ b/src/Generation/Streamers/TextStreamer.php
@@ -88,6 +88,9 @@ use InvalidArgumentException;
  */
 class TextStreamer extends Streamer
 {
+    protected PretrainedTokenizer $tokenizer;
+    protected array $inputTokens = [];
+    protected bool $includeInput = false;
     protected string $printedText = '';
     protected mixed $onStreamCallback = null;
     protected mixed $onStreamEndCallback = null;
@@ -96,13 +99,28 @@ class TextStreamer extends Streamer
     protected int $lastDecodedCheckpointForToken = 0;
     protected int $lastDecodedCheckpointForText = 0;
 
-    public function __construct(protected PretrainedTokenizer $tokenizer)
+    public function __construct()
     {
     }
 
-    public static function make(PretrainedTokenizer $tokenizer): self
+    public static function make(): self
     {
-        return new static($tokenizer);
+        return new static();
+    }
+
+    public function init(PretrainedTokenizer $tokenizer, array $inputTokens, bool $includeInput): void
+    {
+        $this->tokenizer = $tokenizer;
+        $this->inputTokens = $inputTokens;
+        $this->includeInput = $includeInput;
+
+        if (!$this->includeInput) {
+            $this->printedText = $this->tokenizer->decode($this->inputTokens, skipSpecialTokens: true);
+            $this->printedLength = mb_strlen($this->printedText);
+
+            $this->lastDecodedCheckpointForToken = count($this->inputTokens);
+            $this->lastDecodedCheckpointForText = mb_strlen($this->printedText);
+        }
     }
 
     public function onStream(callable $callback): self

--- a/src/Generation/Streamers/TextStreamer.php
+++ b/src/Generation/Streamers/TextStreamer.php
@@ -90,7 +90,7 @@ class TextStreamer extends Streamer
 {
     protected PretrainedTokenizer $tokenizer;
     protected array $inputTokens = [];
-    protected bool $includeInput = false;
+    protected bool $excludeInput = true;
     protected string $printedText = '';
     protected mixed $onStreamCallback = null;
     protected mixed $onStreamEndCallback = null;
@@ -108,13 +108,13 @@ class TextStreamer extends Streamer
         return new static();
     }
 
-    public function init(PretrainedTokenizer $tokenizer, array $inputTokens, bool $includeInput): void
+    public function init(PretrainedTokenizer $tokenizer, array $inputTokens, bool $excludeInput = false): void
     {
         $this->tokenizer = $tokenizer;
         $this->inputTokens = $inputTokens;
-        $this->includeInput = $includeInput;
+        $this->excludeInput = $excludeInput;
 
-        if (!$this->includeInput) {
+        if ($this->excludeInput) {
             $this->printedText = $this->tokenizer->decode($this->inputTokens, skipSpecialTokens: true);
             $this->printedLength = mb_strlen($this->printedText);
 

--- a/src/Pipelines/Text2TextGenerationPipeline.php
+++ b/src/Pipelines/Text2TextGenerationPipeline.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 
 namespace Codewithkyrian\Transformers\Pipelines;
 
+use Codewithkyrian\Transformers\Generation\Streamers\Streamer;
 use Codewithkyrian\Transformers\Utils\GenerationConfig;
-use Codewithkyrian\Transformers\Utils\Tensor;
 
 /**
  * A pipeline for generating text using a model that performs text-to-text generation tasks.
@@ -31,6 +31,7 @@ class Text2TextGenerationPipeline extends Pipeline
         $streamer = null;
 
         if (array_key_exists('streamer', $args)) {
+            /** @var Streamer $streamer */
             $streamer = $args['streamer'];
             unset($args['streamer']);
         }
@@ -76,6 +77,9 @@ class Text2TextGenerationPipeline extends Pipeline
             ? $tokenizer->buildTranslationInputs($inputs, $generateKwargs, padding: true, truncation: true)['input_ids']
             : $tokenizer->__invoke($inputs, padding: true, truncation: true)['input_ids'];
 
+
+        // Streamer can only handle one input at a time for now, so we only pass the first input
+        $streamer->init($this->tokenizer, $inputIds[0]->toArray(), true);
 
         // Generate output token ids
         $outputTokenIds = $this->model->generate($inputIds, generationConfig: $generateKwargs, streamer: $streamer);

--- a/src/Pipelines/Text2TextGenerationPipeline.php
+++ b/src/Pipelines/Text2TextGenerationPipeline.php
@@ -79,7 +79,7 @@ class Text2TextGenerationPipeline extends Pipeline
 
 
         // Streamer can only handle one input at a time for now, so we only pass the first input
-        $streamer->init($this->tokenizer, $inputIds[0]->toArray(), true);
+        $streamer->init($this->tokenizer, $inputIds[0]->toArray());
 
         // Generate output token ids
         $outputTokenIds = $this->model->generate($inputIds, generationConfig: $generateKwargs, streamer: $streamer);

--- a/src/Pipelines/TextGenerationPipeline.php
+++ b/src/Pipelines/TextGenerationPipeline.php
@@ -114,7 +114,7 @@ class TextGenerationPipeline extends Pipeline
         );
 
         // Streamer can only handle one input at a time for now, so we only pass the first input
-        $streamer->init($this->tokenizer, $inputIds[0]->toArray(), false);
+        $streamer->init($this->tokenizer, $inputIds[0]->toArray(), true);
 
         $outputTokenIds = $this->model->generate($inputIds,
             generationConfig: $generationConfig,


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

This PR refines the existing detection for chat input in Text Generation Pipeline. Now the pipeline can correctly detect if the input is a chat input, and apply chat templates to it. It also modifies the pipeline to optionally accept a parameter that controls if it returns the full text as input or not. 

It also includes a refactor to the Streamer class, making it more streamlined, and responsive to the output of text generation models. 