### PR TITLE
bugfix: Decoder sequence not calling the right method

### DIFF
--- a/src/Decoders/DecoderSequence.php
+++ b/src/Decoders/DecoderSequence.php
@@ -29,7 +29,7 @@ class DecoderSequence extends Decoder
     {
         return array_reduce(
             $this->decoders,
-            fn(array $tokens, Decoder $decoder) => $decoder->decode($tokens),
+            fn(array $tokens, Decoder $decoder) => $decoder->decodeChain($tokens),
             $tokens
         );
     }

--- a/src/Decoders/ReplaceDecoder.php
+++ b/src/Decoders/ReplaceDecoder.php
@@ -20,10 +20,17 @@ class ReplaceDecoder extends Decoder
     {
         $pattern = $this->config['pattern'] ?? null;
 
+
         return $pattern == null ?
             $tokens :
             array_map(function ($token) use ($pattern) {
-                return str_replace($pattern, $this->config['content'], $token);
+                if (isset($pattern['Regex'])) {
+                    return preg_replace("/{$pattern['Regex']}/u", $this->config['content'], (string)$token);
+                } elseif (isset($pattern['String'])) {
+                    return str_replace($pattern['String'], $this->config['content'], (string)$token);
+                } else {
+                    return $token;
+                }
             }, $tokens);
     }
 }


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

- Fixes bug with Decoder sequence `decodeChain` not correctly invoking the right methods for the child decoders
- Fixes bug with Replace Decoder not correctly handling the replace pattern
