### PR TITLE
Fix namespace for \Imagine\Gd\Imagine()

### DIFF
--- a/src/Transformers.php
+++ b/src/Transformers.php
@@ -32,7 +32,7 @@ class Transformers
     {
         Image::$imagine = match (self::$imageDriver) {
             ImageDriver::IMAGICK => new \Imagine\Imagick\Imagine(),
-            ImageDriver::GD => new \Imagine\GD\Imagine(),
+            ImageDriver::GD => new \Imagine\Gd\Imagine(),
             ImageDriver::VIPS => new \Imagine\Vips\Imagine(),
         };
     }


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the TransformersPHP team to understand the PR and also work on it.
-->

### What:

- [X] Bug Fix
- [ ] New Feature

### Description:

As far as I can tell the Imagine namespace for GD is `\Imagine\Gd\Imagine()` and not `\Imagine\GD\Imagine()`.
According to the Imagine history this has been true for the last several years and is not a recent change which means this isn't a BC break.

