### PR TITLE
configuration.md: fix indentation of Transformers::setup()

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,7 +16,7 @@ models, and the remote path template. These settings allow you to tailor how and
 use Codewithkyrian\Transformers\Transformers;
 use Codewithkyrian\Transformers\Utils\ImageDriver;
 
- Transformers::setup()
+Transformers::setup()
         ->setCacheDir('/path/to/models')
         ->setImageDriver(ImageDriver::IMAGICK)
         ->setRemoteHost('https://yourmodelshost.com')


### PR DESCRIPTION
### What:

- [x] Documentation Fix

### Description:

Just a small fix to align the text.

I am not sure why it keeps changing the last line too (201), tried it two times.