### PR TITLE
fix: statically calling FFI::new deprecated in PHP 8.3

### DIFF
--- a/src/Tensor/TensorBuffer.php
+++ b/src/Tensor/TensorBuffer.php
@@ -192,7 +192,8 @@ class TensorBuffer implements LinearBuffer
 
         if ($byteSize === 0) return '';
 
-        $buf = FFI::new("char[$byteSize]");
+        $buf = self::$ffi->new("char[$byteSize]");
+
         FFI::memcpy($buf, $this->data, $byteSize);
 
         return FFI::string($buf, $byteSize);


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature
