### PR TITLE
fix: improve regex for detecting language codes in NllbTokenizer

### DIFF
--- a/examples/pipelines/translation.php
+++ b/examples/pipelines/translation.php
@@ -11,11 +11,13 @@ use function Codewithkyrian\Transformers\Utils\timeUsage;
 
 ini_set('memory_limit', -1);
 
-$translator = pipeline('translation', 'Xenova/m2m100_418M');
+//$translator = pipeline('translation', 'Xenova/m2m100_418M');
+$translator = pipeline('translation', 'Xenova/nllb-200-distilled-600M');
 
 $streamer = StdOutStreamer::make();
 
-$output = $translator('生活就像一盒巧克力。', streamer: $streamer, tgtLang: 'en');
+//$output = $translator('生活就像一盒巧克力。', streamer: $streamer, tgtLang: 'en');
+$output = $translator('जीवन एक चॉकलेट बॉक्स की तरह है।', streamer: $streamer, tgtLang: 'fra_Latn');
 //$output = $translator('जीवन एक चॉकलेट बॉक्स की तरह है।', streamer: $streamer, tgtLang: 'fr');
 //$output = $translator('संयुक्त राष्ट्र के प्रमुख का कहना है कि सीरिया में कोई सैन्य समाधान नहीं है', streamer: $streamer, tgtLang: 'fr', maxNewTokens: 256);
 

--- a/src/Normalizers/Replace.php
+++ b/src/Normalizers/Replace.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-
 namespace Codewithkyrian\Transformers\Normalizers;
 
 /**

--- a/src/PretrainedTokenizers/NllbTokenizer.php
+++ b/src/PretrainedTokenizers/NllbTokenizer.php
@@ -10,7 +10,7 @@ use Codewithkyrian\Transformers\Utils\GenerationConfig;
 
 class NllbTokenizer extends PretrainedTokenizer
 {
-    protected string $languageRegex = '/^[a-z]{3}_[A-Z]{3}$/';
+    protected string $languageRegex = '/^[a-z]{3}_[a-zA-Z]{3,4}$/';
 
     protected array $languageCodes = [];
     protected \Closure $langToToken;


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

- Updated the regex pattern from `/^[a-z]{3}_[A-Z]{3}$/` to `/^[a-z]{3}_[a-zA-Z]{3,4}$/` to accommodate additional language code formats such as `eng_Latn` used by some models like `Xenova/nllb-200-distilled-600M`.
- This change ensures better compatibility without significant penalties for false positives.
- Thanks to @Thorry84 for the suggestion.
