### PR TITLE
feat: add optional host argument for model download

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -73,6 +73,9 @@ Arguments:
       can use the shorthand `-q` instead of `--quantized`. Example: `--quantized=false`, `-q false`.
     - `--model-filename=<filename>`: Specify the exact model filename to download (without the `.onnx` suffix. Eg. "
       model" or "model_quantized".
+  - `--host=<remote_host>`: Choose a different model hub host. Instead of fetching models from the Hugging Face model
+    hub, you can use a different host. You can use a private model hub or mirror the original hub.
+    Eg. `--host=https://hf.co`
 
 The `download` command will download the model weights and save them to the cache directory. The next time you use the
 model, TransformersPHP will use the cached weights instead of downloading them again.

--- a/src/Commands/DownloadModelCommand.php
+++ b/src/Commands/DownloadModelCommand.php
@@ -59,6 +59,14 @@ class DownloadModelCommand extends Command
             'The filename of the exact model weights version to download.',
             null
         );
+        
+        $this->addOption(
+            'host',
+            null,
+            InputOption::VALUE_OPTIONAL,
+            'The host to download the model from.',
+            null
+        );
 
     }
 
@@ -71,9 +79,11 @@ class DownloadModelCommand extends Command
         $quantized = filter_var($input->getOption('quantized'), FILTER_VALIDATE_BOOLEAN);
         $task = $input->getArgument('task');
         $modelFilename = $input->getOption('model-filename');
-
+        $host = $input->getOption('host') ?? Transformers::$remoteHost;
+        
         Transformers::setup()
             ->setCacheDir($cacheDir)
+            ->setRemoteHost(rtrim($host,'/'))
             ->apply();
 
         try {


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the TransformersPHP team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [x] New Feature

### Description:
- add optional host argument for model download
- example: ```transformers download Xenova/detr-resnet-50 --host https://hf-mirror.com```