### PR TITLE
Obviate the need for autoload.php in establishing library base path

### DIFF
--- a/src/Utils/Helpers.php
+++ b/src/Utils/Helpers.php
@@ -168,6 +168,6 @@ function getBoundingBox(array $box, bool $asInteger): array
  */
 function basePath(string $dir = ""): string
 {
-    return joinPaths(__DIR__.'/../..', $dir);
+    return joinPaths(dirname(__DIR__,2), $dir);
 }
 

--- a/src/Utils/Helpers.php
+++ b/src/Utils/Helpers.php
@@ -168,10 +168,6 @@ function getBoundingBox(array $box, bool $asInteger): array
  */
 function basePath(string $dir = ""): string
 {
-    $loader = require 'vendor/autoload.php';
-
-    $transformersClass = $loader->findFile(Transformers::class);
-
-    return joinPaths(dirname($transformersClass, 2), $dir);
+    return joinPaths(__DIR__.'/../..', $dir);
 }
 


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [ ] New Feature
- [x] Workaround

### Description:

One of my environments doesn't have the `vendor` directory on the PHP `include_path`, so I had do this for my own purposes. However, it seems unnecessary to use the autoloader just to establish the root of the library.

