### PR TITLE
Fix crop coordinates calc in  Image.php

### DIFF
--- a/src/Utils/Image.php
+++ b/src/Utils/Image.php
@@ -288,8 +288,8 @@ class Image
         // Ensure crop bounds are within the image
         $xMin = max($xMin, 0);
         $yMin = max($yMin, 0);
-        $xMax = max($xMax, $originalWidth - 1);
-        $yMax = max($yMax, $originalHeight - 1);
+        $xMax = min($xMax, $originalWidth - 1);
+        $yMax = min($yMax, $originalHeight - 1);
 
         $cropWidth = $xMax - $xMin + 1;
         $cropHeight = $yMax - $yMin + 1;


### PR DESCRIPTION
fix Max points calculation to actually crop

<!--
- Fill in the form below correctly. This will help the TransformersPHP team to understand the PR and also work on it.
-->

### What:

- [x ] Bug Fix
- [ ] New Feature

### Description:

#### Summary:
This PR addresses an issue in the `crop` method where the provided `$xMax` and `$yMax` crop values could erroneously cause the image to be cropped to the original bottom-right corner of the image. Instead of adhering to the user-provided `$xMax` and `$yMax` values, the previous version would limit the cropping operation to the original dimensions of the image, thus ignoring the intended bounds of the cropping area.

#### Problem:
In the previous implementation:
- The `$xMax` and `$yMax` values were being set using the `max()` function but without properly limiting them to the correct image bounds. This could lead to unintended cropping to the original image dimensions, effectively defeating the purpose of a custom crop box.
  
For example, if a user intended to crop a portion of the image smaller than the original dimensions (e.g., cropping to a sub-box within the image), the logic failed by automatically expanding the crop back to the original width and height. 

#### Fix:
- Replaced the incorrect logic for `$xMax` and `$yMax` with `min()` instead of `max()`, to properly limit these values only when they exceed the image's bounds.

### Related:

<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->
