### PR TITLE
Add PSR-3 compliant logging interface and default StreamLogger

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Transformers::setup()
     ->setAuthToken('...') // Set the auth token for downloading models. Defaults to `null`
     ->setUserAgent('...') // Set the user agent for downloading models. Defaults to `transformers-php/{version}`
     ->setImageDriver('...') // Set the image driver for processing images. Defaults to `IMAGICK'
-    ->apply(); // Apply the configuration
+    ->setLogger('...'); // Set the logger for TransformersPHP. Defaults to `null`
 ```
 
 You can call the `set` methods in any order, or leave any out entirely, in which case, it uses the default values. For

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
   "require": {
     "php": "^8.1",
     "ext-ffi": "*",
+    "psr/log": "^1.1.3|^2.0|^3.0",
     "codewithkyrian/jinja-php": "^1.0",
     "codewithkyrian/transformers-libsloader": "^2.0",
     "imagine/imagine": "^1.3",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,7 +22,8 @@ Transformers::setup()
         ->setRemotePathTemplate('custom/path/{model}/{file}')
         ->setAuthToken('your-token')
         ->setUserAgent('your-user-agent')
-        ->setImageDriver(ImageDriver::IMAGICK);
+        ->setImageDriver(ImageDriver::IMAGICK)
+        ->setLogger(new StreamLogger('transformers-php'));
 ```
 
 ::: tip
@@ -104,6 +105,14 @@ Transformers::setup()
     ->setImageDriver(ImageDriver::GD)
     ->apply();
 ```
+
+### `setLogger(LoggerInterface $logger)`
+
+This setting allows you to set a custom logger for TransformersPHP. No logger is set by default, but you can set a
+logger to debug TransformersPHP's internal behavior. The logger should implement the `Psr\Log\LoggerInterface` interface. TransformersPHP
+comes with a `StreamLogger` class, similar to Monolog's `StreamHandler`, which can be used to log to a stream (STDOUT, STDERR,
+or a file) and can be customized to log at different levels (debug, info, warning, error, critical). You can also pass in a 
+logger that is already configured and ready to use e.g. a Laravel logger.
 
 ## Standalone PHP Projects
 

--- a/examples/bootstrap.php
+++ b/examples/bootstrap.php
@@ -11,4 +11,4 @@ require_once './vendor/autoload.php';
 Transformers::setup()
     ->setCacheDir('/Users/Kyrian/.transformers')
     ->setImageDriver(ImageDriver::VIPS)
-    ->setLogger(new StreamLogger());
+    ->setLogger(new StreamLogger(STDOUT));

--- a/examples/bootstrap.php
+++ b/examples/bootstrap.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 use Codewithkyrian\Transformers\Transformers;
 use Codewithkyrian\Transformers\Utils\ImageDriver;
+use Codewithkyrian\Transformers\Utils\StdoutLogger;
 
 require_once './vendor/autoload.php';
 
 Transformers::setup()
     ->setCacheDir('/Users/Kyrian/.transformers')
-    ->setImageDriver(ImageDriver::VIPS);
+    ->setImageDriver(ImageDriver::VIPS)
+    ->setLogger(new StdoutLogger());

--- a/examples/bootstrap.php
+++ b/examples/bootstrap.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 use Codewithkyrian\Transformers\Transformers;
 use Codewithkyrian\Transformers\Utils\ImageDriver;
-use Codewithkyrian\Transformers\Utils\StdoutLogger;
+use Codewithkyrian\Transformers\Utils\StreamLogger;
 
 require_once './vendor/autoload.php';
 
 Transformers::setup()
     ->setCacheDir('/Users/Kyrian/.transformers')
     ->setImageDriver(ImageDriver::VIPS)
-    ->setLogger(new StdoutLogger());
+    ->setLogger(new StreamLogger());

--- a/examples/pipelines/asr.php
+++ b/examples/pipelines/asr.php
@@ -26,8 +26,8 @@ $audioUrl = __DIR__ . '/../sounds/ted_60.wav';
 //$audioUrl = __DIR__ . '/../sounds/sample-1.mp3';
 
 $streamer = WhisperTextStreamer::make()
-//->onTimestampStart(fn($timestamp) => dump($timestamp));
 ->onStream(fn($text) => print($text));
+
 
 $output = $transcriber($audioUrl,
     maxNewTokens: 256,

--- a/src/Models/Auto/PretrainedMixin.php
+++ b/src/Models/Auto/PretrainedMixin.php
@@ -8,6 +8,7 @@ namespace Codewithkyrian\Transformers\Models\Auto;
 use Codewithkyrian\Transformers\Exceptions\UnsupportedModelTypeException;
 use Codewithkyrian\Transformers\Models\ModelArchitecture;
 use Codewithkyrian\Transformers\Models\Pretrained\PretrainedModel;
+use Codewithkyrian\Transformers\Transformers;
 use Codewithkyrian\Transformers\Utils\AutoConfig;
 
 /**
@@ -18,6 +19,7 @@ abstract class PretrainedMixin
 {
     /**
      * Mapping from model type to model class.
+     *
      * @var array<string, array<string, string>> The model class mappings.
      */
     const MODEL_CLASS_MAPPINGS = [];
@@ -37,15 +39,16 @@ abstract class PretrainedMixin
      * @param string|null $cacheDir The cache directory to save the model in.
      * @param string $revision The revision of the model.
      * @param string|null $modelFilename The filename of the model.
+     *
      * @return PretrainedModel The instantiated pretrained model.
      */
     public static function fromPretrained(
-        string           $modelNameOrPath,
-        bool             $quantized = true,
-        ?array           $config = null,
-        ?string          $cacheDir = null,
-        string           $revision = 'main',
-        ?string          $modelFilename = null,
+        string    $modelNameOrPath,
+        bool      $quantized = true,
+        ?array    $config = null,
+        ?string   $cacheDir = null,
+        string    $revision = 'main',
+        ?string   $modelFilename = null,
         ?callable $onProgress = null
     ): PretrainedModel
     {
@@ -53,7 +56,6 @@ abstract class PretrainedMixin
 
         foreach (static::MODEL_CLASS_MAPPINGS as $modelClassMapping) {
             $modelClass = $modelClassMapping[$config->modelType] ?? null;
-
 
             if ($modelClass === null) continue;
 
@@ -72,7 +74,7 @@ abstract class PretrainedMixin
         }
 
         if (static::BASE_IF_FAIL) {
-//            echo "Unknown model class for model type {$config->modelType}. Using base class PreTrainedModel.";
+            Transformers::getLogger()->warning("Unknown model class for model type {$config->modelType}. Using base class PreTrainedModel.");
 
             return PretrainedModel::fromPretrained(
                 modelNameOrPath: $modelNameOrPath,

--- a/src/Models/Pretrained/VisionEncoderDecoderModel.php
+++ b/src/Models/Pretrained/VisionEncoderDecoderModel.php
@@ -9,6 +9,7 @@ namespace Codewithkyrian\Transformers\Models\Pretrained;
 use Codewithkyrian\Transformers\Models\Auto\AutoModel;
 use Codewithkyrian\Transformers\Models\Auto\AutoModelForCausalLM;
 use Codewithkyrian\Transformers\Models\ModelArchitecture;
+use Codewithkyrian\Transformers\Transformers;
 use Codewithkyrian\Transformers\Utils\AutoConfig;
 use Codewithkyrian\Transformers\Utils\GenerationConfig;
 use Codewithkyrian\Transformers\Utils\InferenceSession;
@@ -32,6 +33,7 @@ class VisionEncoderDecoderModel extends PretrainedModel
 
     /**
      * Creates a new instance of the `VisionEncoderDecoderModel` class.
+     *
      * @param AutoConfig $config The configuration array specifying the hyperparameters and other model settings.
      * @param mixed $session The ONNX session containing the encoder model.
      * @param InferenceSession $decoderMergedSession The ONNX session containing the merged decoder model.
@@ -60,7 +62,7 @@ class VisionEncoderDecoderModel extends PretrainedModel
             ?? AutoModel::ENCODER_DECODER_MODEL_MAPPING[$encoderModelType];
 
         if (!$encoderModel) {
-            echo "Model type for encoder '{$encoderModelType}' not found, assuming encoder-only architecture. Please report this at https://github.com/CodeWithKyrian/transformers-php/issues/new/choose.";
+            Transformers::getLogger()?->warning("Model type for encoder '{$encoderModelType}' not found, assuming encoder-only architecture. Please report this at https://github.com/CodeWithKyrian/transformers-php/issues/new/choose.");
         }
 
         // Validate decoder

--- a/src/Pipelines/ZeroShotClassificationPipeline.php
+++ b/src/Pipelines/ZeroShotClassificationPipeline.php
@@ -8,6 +8,7 @@ namespace Codewithkyrian\Transformers\Pipelines;
 use Codewithkyrian\Transformers\Models\Output\SequenceClassifierOutput;
 use Codewithkyrian\Transformers\Models\Pretrained\PretrainedModel;
 use Codewithkyrian\Transformers\PreTrainedTokenizers\PreTrainedTokenizer;
+use Codewithkyrian\Transformers\Transformers;
 use Codewithkyrian\Transformers\Utils\Math;
 use function Codewithkyrian\Transformers\Utils\timeUsage;
 
@@ -68,13 +69,13 @@ class ZeroShotClassificationPipeline extends Pipeline
         $this->entailmentId = $this->label2id['entailment'] ?? null;
 
         if ($this->entailmentId === null) {
-            echo "Could not find 'entailment' in label2id mapping. Using 2 as entailment_id.\n";
+            Transformers::getLogger()?->warning("Could not find 'entailment' in label2id mapping. Using 2 as entailment_id.");
             $this->entailmentId = 2;
         }
 
         $this->contradictionId = $this->label2id['contradiction'] ?? $this->label2id['not_entailment'] ?? null;
         if ($this->contradictionId === null) {
-            echo "Could not find 'contradiction' in label2id mapping. Using 0 as contradiction_id.\n";
+            Transformers::getLogger()?->warning("Could not find 'contradiction' in label2id mapping. Using 0 as contradiction_id.");
             $this->contradictionId = 0;
         }
     }

--- a/src/PreTrainedTokenizers/AutoTokenizer.php
+++ b/src/PreTrainedTokenizers/AutoTokenizer.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
 namespace Codewithkyrian\Transformers\PreTrainedTokenizers;
 
 use Codewithkyrian\Transformers\Tokenizers\TokenizerModel;
+use Codewithkyrian\Transformers\Transformers;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -41,7 +42,7 @@ class AutoTokenizer
         'WhisperTokenizer' => WhisperTokenizer::class,
         'CodeGenTokenizer' => CodeGenTokenizer::class,
         'CLIPTokenizer' => CLIPTokenizer::class,
-         'SiglipTokenizer' => SiglipTokenizer::class,
+        'SiglipTokenizer' => SiglipTokenizer::class,
         // 'MarianTokenizer' => MarianTokenizer::class,
         'BloomTokenizer' => BloomTokenizer::class,
         'NllbTokenizer' => NllbTokenizer::class,
@@ -82,6 +83,7 @@ class AutoTokenizer
      * @param string $revision
      * @param mixed $legacy
      * @param OutputInterface|null $output
+     *
      * @return PreTrainedTokenizer|null
      */
     public static function fromPretrained(
@@ -104,7 +106,7 @@ class AutoTokenizer
         $cls = self::TOKENIZER_CLASS_MAPPING[$tokenizerClassName] ?? null;
 
         if ($cls == null) {
-            echo "Unknown tokenizer class $tokenizerClassName. Using PreTrainedTokenizer. \n";
+            Transformers::getLogger()?->warning("Unknown tokenizer class $tokenizerClassName. Using PreTrainedTokenizer.");
 
             $cls = PreTrainedTokenizer::class;
         }

--- a/src/Transformers.php
+++ b/src/Transformers.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Codewithkyrian\Transformers;
 
 use Codewithkyrian\Transformers\Utils\ImageDriver;
+use Psr\Log\LoggerInterface;
 use RuntimeException;
 
 class Transformers
@@ -21,6 +22,7 @@ class Transformers
 
     protected static ImageDriver $imageDriver;
 
+    protected static ?LoggerInterface $logger = null;
 
     /**
      * Returns a new instance of the static class.
@@ -122,6 +124,20 @@ class Transformers
         return $this;
     }
 
+    /**
+     * Set the logger for debugging.
+     *
+     * @param LoggerInterface $logger
+     *
+     * @return $this
+     */
+    public function setLogger(LoggerInterface $logger) : static
+    {
+        self::$logger = $logger;
+
+        return $this;
+    }
+
     public static function getCacheDir(): string
     {
         return self::$cacheDir;
@@ -154,5 +170,10 @@ class Transformers
         }
 
         return self::$imageDriver;
+    }
+
+    public static function getLogger(): ?LoggerInterface
+    {
+        return self::$logger;
     }
 }

--- a/src/Utils/Helpers.php
+++ b/src/Utils/Helpers.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Codewithkyrian\Transformers\Utils;
 
+use Codewithkyrian\Transformers\Transformers;
+
 function memoryUsage(): string
 {
     $mem = memory_get_usage(true);
@@ -188,7 +190,7 @@ function createPattern(array $pattern, bool $invert = true): ?string
         // NOTE: if invert is true, we wrap the pattern in a group so that it is kept when performing split
         return $invert ? $escaped : "($escaped)";
     } else {
-        echo 'Unknown pattern type: '.print_r($pattern, true);
+        Transformers::getLogger()->error('Unknown pattern type: '.print_r($pattern, true));
         return null;
     }
 }

--- a/src/Utils/Helpers.php
+++ b/src/Utils/Helpers.php
@@ -190,7 +190,7 @@ function createPattern(array $pattern, bool $invert = true): ?string
         // NOTE: if invert is true, we wrap the pattern in a group so that it is kept when performing split
         return $invert ? $escaped : "($escaped)";
     } else {
-        Transformers::getLogger()->error('Unknown pattern type: '.print_r($pattern, true));
+        Transformers::getLogger()?->error('Unknown pattern type: '.print_r($pattern, true));
         return null;
     }
 }

--- a/src/Utils/StdoutLogger.php
+++ b/src/Utils/StdoutLogger.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codewithkyrian\Transformers\Utils;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\LoggerTrait;
+
+class StdoutLogger implements LoggerInterface
+{
+    use LoggerTrait;
+    protected const LOG_FORMAT = "[%datetime%] %level_name%: %message% %context%\n";
+    protected const DATE_FORMAT = "Y-m-d\TH:i:sP";
+
+    public function log($level, \Stringable|string $message, array $context = []): void
+    {
+        $params = [
+            '%datetime%' => date(static::DATE_FORMAT),
+            '%level_name%' => $level,
+            '%message%' => $message,
+            '%context%' => json_encode(
+                $context,
+                JSON_UNESCAPED_SLASHES |
+                JSON_UNESCAPED_UNICODE |
+                JSON_PRESERVE_ZERO_FRACTION
+            ),
+        ];
+
+        fwrite(STDOUT, strtr(static::LOG_FORMAT, $params));
+    }
+}

--- a/src/Utils/StreamLogger.php
+++ b/src/Utils/StreamLogger.php
@@ -4,37 +4,273 @@ declare(strict_types=1);
 
 namespace Codewithkyrian\Transformers\Utils;
 
+use InvalidArgumentException;
+use LogicException;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LoggerTrait;
+use Stringable;
+use UnexpectedValueException;
+use function dirname;
+use function ini_get;
+use function is_resource;
+use function is_string;
 
 class StreamLogger implements LoggerInterface
 {
     use LoggerTrait;
 
-    protected const LOG_FORMAT = "[%datetime%] %level_name%: %message% %context%\n";
-    protected const DATE_FORMAT = "Y-m-d\TH:i:sP";
+    protected const LOG_FORMAT = "[%datetime%] whisper.%level_name%: %message% %context%\n";
 
+    protected const DATE_FORMAT = 'Y-m-d H:i:s';
+
+    protected const MAX_CHUNK_SIZE = 2147483647;
+
+    protected const DEFAULT_CHUNK_SIZE = 10 * 1024 * 1024; // 10MB
+
+    protected int $streamChunkSize;
+
+    /** @var ?resource */
+    protected $stream;
+
+    protected ?string $url = null;
+
+    private ?string $errorMessage = null;
+
+    protected ?int $filePermission;
+
+    protected bool $useLocking;
+
+    protected string $fileOpenMode;
+
+    /** @var true|null */
+    private ?bool $dirCreated = null;
+
+    private bool $retrying = false;
 
     /**
-     * @param resource $stream
+     * @param  resource|string  $stream  If a missing path can't be created, an UnexpectedValueException will be thrown on first write
+     * @param  int|null  $filePermission  Optional file permissions (default (0644) are only for owner read/write)
+     * @param  bool  $useLocking  Try to lock log file before doing any writes
+     * @param  string  $fileOpenMode  The fopen() mode used when opening a file, if $stream is a file path
+     *
+     * @throws InvalidArgumentException If stream is not a resource or string
      */
-    public function __construct(protected $stream = STDOUT) {}
-
-
-    public function log($level, \Stringable|string $message, array $context = []): void
+    public function __construct(mixed $stream, ?int $filePermission = null, bool $useLocking = false, string $fileOpenMode = 'a')
     {
-        $params = [
-            '%datetime%' => date(static::DATE_FORMAT),
-            '%level_name%' => $level,
-            '%message%' => $message,
-            '%context%' => json_encode(
-                $context,
-                JSON_UNESCAPED_SLASHES |
-                JSON_UNESCAPED_UNICODE |
-                JSON_PRESERVE_ZERO_FRACTION
-            ),
-        ];
 
-        fwrite($this->stream, strtr(static::LOG_FORMAT, $params));
+        if (($phpMemoryLimit = self::getMemoryLimitInBytes()) !== false) {
+            if ($phpMemoryLimit > 0) {
+                // use max 10% of allowed memory for the chunk size, and at least 100KB
+                $this->streamChunkSize = min(static::MAX_CHUNK_SIZE, max((int) ($phpMemoryLimit / 10), 100 * 1024));
+            } else {
+                // memory is unlimited, set to the default 10MB
+                $this->streamChunkSize = static::DEFAULT_CHUNK_SIZE;
+            }
+        } else {
+            // no memory limit information, set to the default 10MB
+            $this->streamChunkSize = static::DEFAULT_CHUNK_SIZE;
+        }
+
+        if (is_resource($stream)) {
+            $this->stream = $stream;
+
+            stream_set_chunk_size($this->stream, $this->streamChunkSize);
+        } elseif (is_string($stream)) {
+            $this->url = self::canonicalizePath($stream);
+        } else {
+            throw new InvalidArgumentException('A stream must either be a resource or a string.');
+        }
+
+        $this->fileOpenMode = $fileOpenMode;
+        $this->filePermission = $filePermission;
+        $this->useLocking = $useLocking;
+    }
+
+    public function log($level, Stringable|string $message, array $context = []): void
+    {
+        if (! is_resource($this->stream)) {
+            $url = $this->url;
+            if ($url === null || $url === '') {
+                throw new LogicException('Missing stream url, the stream can not be opened. This may be caused by a premature call to close()');
+            }
+            $this->createDir($url);
+            $this->errorMessage = null;
+            set_error_handler($this->customErrorHandler(...));
+
+            try {
+                $stream = fopen($url, $this->fileOpenMode);
+                if ($this->filePermission !== null) {
+                    @chmod($url, $this->filePermission);
+                }
+            } finally {
+                restore_error_handler();
+            }
+            if (! is_resource($stream)) {
+                $this->stream = null;
+
+                throw new UnexpectedValueException('The stream could not be opened in append mode');
+            }
+            stream_set_chunk_size($stream, $this->streamChunkSize);
+            $this->stream = $stream;
+        }
+
+        $stream = $this->stream;
+        if ($this->useLocking) {
+            // ignoring errors here, there's not much we can do about them
+            flock($stream, LOCK_EX);
+        }
+
+        $this->errorMessage = null;
+        set_error_handler($this->customErrorHandler(...));
+        try {
+
+            $params = [
+                '%datetime%' => date(static::DATE_FORMAT),
+                '%level_name%' => $level,
+                '%message%' => trim($message),
+                '%context%' => json_encode(
+                    $context,
+                    JSON_UNESCAPED_SLASHES |
+                    JSON_UNESCAPED_UNICODE |
+                    JSON_PRESERVE_ZERO_FRACTION
+                ),
+            ];
+            fwrite($stream, strtr(static::LOG_FORMAT, $params));
+        } finally {
+            restore_error_handler();
+        }
+        if ($this->errorMessage !== null) {
+            // close the resource if possible to reopen it, and retry the failed write
+            if (! $this->retrying && $this->url !== null && $this->url !== 'php://memory') {
+                $this->retrying = true;
+                $this->close();
+                $this->log($level, $message, $context);
+
+                return;
+            }
+
+            throw new UnexpectedValueException('Writing to the log file failed');
+        }
+
+        $this->retrying = false;
+        if ($this->useLocking) {
+            flock($stream, LOCK_UN);
+        }
+    }
+
+    public function close(): void
+    {
+        if ($this->url !== null && is_resource($this->stream)) {
+            fclose($this->stream);
+        }
+        $this->stream = null;
+        $this->dirCreated = null;
+    }
+
+    private function getDirFromStream(string $stream): ?string
+    {
+        $pos = strpos($stream, '://');
+        if ($pos === false) {
+            return dirname($stream);
+        }
+
+        if (str_starts_with($stream, 'file://')) {
+            return dirname(substr($stream, 7));
+        }
+
+        return null;
+    }
+
+    private function customErrorHandler(int $code, string $msg): bool
+    {
+        $this->errorMessage = preg_replace('{^(fopen|mkdir|fwrite)\(.*?\): }', '', $msg);
+
+        return true;
+    }
+
+    private function createDir(string $url): void
+    {
+        // Do not try to create dir if it has already been tried.
+        if ($this->dirCreated === true) {
+            return;
+        }
+
+        $dir = $this->getDirFromStream($url);
+        if ($dir !== null && ! is_dir($dir)) {
+            $this->errorMessage = null;
+            set_error_handler(function (...$args) {
+                return $this->customErrorHandler(...$args);
+            });
+            $status = mkdir($dir, 0777, true);
+            restore_error_handler();
+            if ($status === false && ! is_dir($dir) && ! str_contains((string) $this->errorMessage, 'File exists')) {
+                throw new UnexpectedValueException(sprintf('There is no existing directory at "%s" and it could not be created: '.$this->errorMessage, $dir));
+            }
+        }
+        $this->dirCreated = true;
+    }
+
+    protected static function getMemoryLimitInBytes(): false|int
+    {
+        $limit = ini_get('memory_limit');
+        if (! is_string($limit)) {
+            return false;
+        }
+
+        // support -1
+        if ((int) $limit < 0) {
+            return (int) $limit;
+        }
+
+        if (!preg_match('/^\s*(?<limit>\d+)(?:\.\d+)?\s*(?<unit>[gmk]?)\s*$/i', $limit, $match)) {
+            return false;
+        }
+
+        $limit = (int) $match['limit'];
+        switch (strtolower($match['unit'])) {
+            case 'g':
+                $limit *= 1024;
+            // no break
+            case 'm':
+                $limit *= 1024;
+            // no break
+            case 'k':
+                $limit *= 1024;
+        }
+
+        return $limit;
+    }
+
+    /**
+     * Makes sure if a relative path is passed in it is turned into an absolute path
+     *
+     * @param  string  $streamUrl  stream URL or path without protocol
+     */
+    public static function canonicalizePath(string $streamUrl): string
+    {
+        $prefix = '';
+        if (str_starts_with($streamUrl, 'file://')) {
+            $streamUrl = substr($streamUrl, 7);
+            $prefix = 'file://';
+        }
+
+        // other type of stream, not supported
+        if (str_contains($streamUrl, '://')) {
+            return $streamUrl;
+        }
+
+        // already absolute
+        if (str_starts_with($streamUrl, '/') || substr($streamUrl, 1, 1) === ':' || str_starts_with($streamUrl, '\\\\')) {
+            return $prefix.$streamUrl;
+        }
+
+        $streamUrl = getcwd().'/'.$streamUrl;
+
+        return $prefix.$streamUrl;
+    }
+
+    public function __destruct()
+    {
+        $this->close();
     }
 }

--- a/src/Utils/StreamLogger.php
+++ b/src/Utils/StreamLogger.php
@@ -7,11 +7,19 @@ namespace Codewithkyrian\Transformers\Utils;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LoggerTrait;
 
-class StdoutLogger implements LoggerInterface
+class StreamLogger implements LoggerInterface
 {
     use LoggerTrait;
+
     protected const LOG_FORMAT = "[%datetime%] %level_name%: %message% %context%\n";
     protected const DATE_FORMAT = "Y-m-d\TH:i:sP";
+
+
+    /**
+     * @param resource $stream
+     */
+    public function __construct(protected $stream = STDOUT) {}
+
 
     public function log($level, \Stringable|string $message, array $context = []): void
     {
@@ -27,6 +35,6 @@ class StdoutLogger implements LoggerInterface
             ),
         ];
 
-        fwrite(STDOUT, strtr(static::LOG_FORMAT, $params));
+        fwrite($this->stream, strtr(static::LOG_FORMAT, $params));
     }
 }

--- a/tests/Utils/StreamLoggerTest.php
+++ b/tests/Utils/StreamLoggerTest.php
@@ -1,0 +1,83 @@
+<?php
+
+use Codewithkyrian\Transformers\Utils\StreamLogger;
+
+beforeEach(function () {
+    $this->outputBuffer = fopen('php://memory', 'rw');
+    $this->logger = new StreamLogger($this->outputBuffer);
+});
+
+afterEach(function () {
+    fclose($this->outputBuffer);
+});
+
+it('logs messages with the correct format', function () {
+    $this->logger->log('info', 'This is a test message');
+
+    rewind($this->outputBuffer);
+    $output = stream_get_contents($this->outputBuffer);
+
+    expect($output)->toMatch('/\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[\+\-]\d{2}:\d{2}\] info: This is a test message \[\]\n/');
+});
+
+it('handles context correctly in log messages', function () {
+    $context = ['user_id' => 123, 'action' => 'login'];
+    $this->logger->log('warning', 'User action recorded', $context);
+
+    rewind($this->outputBuffer);
+    $output = stream_get_contents($this->outputBuffer);
+
+    $expectedContext = json_encode($context, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION);
+
+    expect($output)->toContain('warning: User action recorded')
+        ->and($output)->toContain($expectedContext);
+});
+
+it('handles different log levels correctly', function () {
+    $levels = ['debug', 'info', 'notice', 'warning', 'error', 'critical', 'alert', 'emergency'];
+
+    foreach ($levels as $level) {
+        $this->logger->log($level, "Message at $level level");
+
+        rewind($this->outputBuffer);
+        $output = stream_get_contents($this->outputBuffer);
+        expect($output)->toContain("$level: Message at $level level");
+
+        ftruncate($this->outputBuffer, 0); // Clear buffer
+        rewind($this->outputBuffer);
+    }
+});
+
+it('handles empty context gracefully', function () {
+    $this->logger->log('info', 'Message with no context');
+
+    rewind($this->outputBuffer);
+    $output = stream_get_contents($this->outputBuffer);
+
+    expect($output)->toContain('info: Message with no context []');
+});
+
+it('handles stringable objects in the message', function () {
+    $stringable = new class {
+        public function __toString(): string
+        {
+            return 'Stringable message content';
+        }
+    };
+
+    $this->logger->log('info', $stringable);
+
+    rewind($this->outputBuffer);
+    $output = stream_get_contents($this->outputBuffer);
+
+    expect($output)->toContain('info: Stringable message content');
+});
+
+it('outputs log messages to STDOUT', function () {
+    $this->logger->log('info', 'Check output redirection');
+
+    rewind($this->outputBuffer);
+    $output = stream_get_contents($this->outputBuffer);
+
+    expect($output)->toContain('info: Check output redirection');
+});


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

This PR introduces a logging implementation, allowing developers to configure a logger for TransformersPHP. 

### What's New
1. Configurable Logger:
    - Added configuration to set logger in `Transformers::setup()`
    - The logger must implement the [PSR-3 Logging Interface](https://www.php-fig.org/psr/psr-3/).
2. Default `StreamLogger`:
   - Introduced a `StreamLogger` implementation that writes log messages to PHP’s `STDOUT` stream. No default logger is set however, and for now, you have to manually set the logger to this `StreamLogger` to use it.
3. Replaced echo Statements:
   - Refactored the package to replace all echo statements with appropriate logging calls, adhering to the PSR-3 standard for structured logging.