### PR TITLE
Fix typo in extend

### DIFF
--- a/src/Models/Pretrained/Qwen2PreTrainedModel.php
+++ b/src/Models/Pretrained/Qwen2PreTrainedModel.php
@@ -13,7 +13,7 @@ use Codewithkyrian\Transformers\Utils\InferenceSession;
 /**
  * The bare Qwen2 Model outputting raw hidden-states without any specific head on top.
  */
-class Qwen2PreTrainedModel extends PreTrainedModel
+class Qwen2PreTrainedModel extends PretrainedModel
 {
     protected int $numHeads;
     protected int $numLayers;


### PR DESCRIPTION
### What:

- [X] Bug Fix
- [ ] New Feature

### Description:

Autoloader failes to load class on case sensitive filesystems, as classname is incorret.

