### PR TITLE
Fix namespace conflict with Transformers class

### DIFF
--- a/src/Pipelines/ZeroShotClassificationPipeline.php
+++ b/src/Pipelines/ZeroShotClassificationPipeline.php
@@ -10,7 +10,6 @@ use Codewithkyrian\Transformers\Models\Pretrained\PretrainedModel;
 use Codewithkyrian\Transformers\PreTrainedTokenizers\PreTrainedTokenizer;
 use Codewithkyrian\Transformers\Transformers;
 use Codewithkyrian\Transformers\Utils\Math;
-use Codewithkyrian\Transformers\Transformers;
 
 /**
  * NLI-based zero-shot classification pipeline using any model that has been fine-tuned on NLI (natural language inference)


### PR DESCRIPTION
### What:

- [x] Bug Fix

### Description:

I got that error (PHP 8.4.7)

`Whoops\Exception\ErrorException 

  Cannot use Codewithkyrian\Transformers\Transformers as Transformers because the name is already in use`

 So I implemented a simple fix