### PR TITLE
Change addCommand call to add

### DIFF
--- a/bin/transformers
+++ b/bin/transformers
@@ -12,7 +12,7 @@ $application = new Application();
 try {
     $application->setName('Transformers PHP CLI');
 
-    $application->addCommand(new Codewithkyrian\Transformers\Commands\DownloadModelCommand());
+    $application->add(new Codewithkyrian\Transformers\Commands\DownloadModelCommand());
 
     $application->run();
 } catch (Exception $e) {


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the TransformersPHP team to understand the PR and also work on it.
-->

### What:

- [X] Bug Fix
- [ ] New Feature

### Description:

Symfony Console component doesn't have `addCommand` method anymore. The method is `add`.

