### PR TITLE
Using correct method to add command to CLI application

### DIFF
--- a/bin/transformers
+++ b/bin/transformers
@@ -12,7 +12,9 @@ $application = new Application();
 try {
     $application->setName('Transformers PHP CLI');
 
-    $application->addCommand(new Codewithkyrian\Transformers\Commands\DownloadModelCommand());
+    // TODO: remove when upgrading to Symfony 8.0 where `addCommand` will be the only option
+    $addCommandMethodName = method_exists($application, 'addCommand') ? 'addCommand' : 'add';
+    $application->$addCommandMethodName(new Codewithkyrian\Transformers\Commands\DownloadModelCommand());
 
     $application->run();
 } catch (Exception $e) {


### PR DESCRIPTION
### What:

- [X] Bug Fix

### Description:

Symfony 7.4 replaced the `add` method with `addCommand`, but the package requires `symfony/console:^6.4|^7.0`, so both methods need to be supported.
