### PR TITLE
allow Symfony 8 components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,12 +23,12 @@
     "rindow/rindow-matlib-ffi": "^1.1",
     "rindow/rindow-openblas-ffi": "^1.0",
     "rokka/imagine-vips": "^0.40",
-    "symfony/console": "^6.4|^7.0"
+    "symfony/console": "^6.4|^7.0|^8.0"
   },
   "require-dev": {
     "ffi/var-dumper": "^1.0",
     "pestphp/pest": "^2.36.0|^3.5.0",
-    "symfony/var-dumper": "^6.4.11|^7.1.5"
+    "symfony/var-dumper": "^6.4.11|^7.1.5|^8.0"
   },
   "suggest": {
     "ext-imagick": "Required to use the Imagick Driver for image processing",


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [ ] New Feature

### Description:

allow the package to be used with version 8 of Symfony components

### Related:

Widening the accepted releases of the Symfony Console component will allow us to already test the Symfony AI packages with the upcoming Symfony 8 major release (see symfony/symfony-ai#277)