### PR TITLE
fix: PHP 8.4 nullable deprecations

### DIFF
--- a/src/PostProcessors/BertProcessing.php
+++ b/src/PostProcessors/BertProcessing.php
@@ -39,7 +39,7 @@ class BertProcessing extends PostProcessor
      * @param bool $addSpecialTokens Whether to add the special tokens associated with the corresponding model.
      * @return PostProcessedOutput
      */
-    public function postProcess(array $tokens, array $tokenPair = null, bool $addSpecialTokens = true): PostProcessedOutput
+    public function postProcess(array $tokens, ?array $tokenPair = null, bool $addSpecialTokens = true): PostProcessedOutput
     {
         if ($addSpecialTokens) {
             $tokens = array_merge([$this->cls], $tokens, [$this->sep]);

--- a/src/PostProcessors/ByteLevelPostProcessor.php
+++ b/src/PostProcessors/ByteLevelPostProcessor.php
@@ -26,7 +26,7 @@ class ByteLevelPostProcessor extends PostProcessor
      * @param bool $addSpecialTokens Whether to add the special tokens associated with the corresponding model.
      * @return PostProcessedOutput
      */
-    public function postProcess(array $tokens, array $tokenPair = null,  bool $addSpecialTokens = true): PostProcessedOutput
+    public function postProcess(array $tokens, ?array $tokenPair = null, bool $addSpecialTokens = true): PostProcessedOutput
     {
         if ($tokenPair !== null) {
             $tokens = array_merge($tokens, $tokenPair);

--- a/src/PostProcessors/TemplateProcessing.php
+++ b/src/PostProcessors/TemplateProcessing.php
@@ -37,7 +37,7 @@ class TemplateProcessing extends PostProcessor
      * @param bool $addSpecialTokens Whether to add the special tokens associated with the corresponding model.
      * @return PostProcessedOutput
      */
-    public function postProcess(array $tokens, array $tokenPair = null,  bool $addSpecialTokens = true): PostProcessedOutput
+    public function postProcess(array $tokens, ?array $tokenPair = null, bool $addSpecialTokens = true): PostProcessedOutput
     {
         $type = $tokenPair === null ? $this->single : $this->pair;
 

--- a/src/PreTrainedTokenizers/WhisperTokenizer.php
+++ b/src/PreTrainedTokenizers/WhisperTokenizer.php
@@ -409,7 +409,7 @@ class WhisperTokenizer extends PreTrainedTokenizer
      * @throws Exception If there is a bug within the function.
      * @private
      */
-    private function findLongestCommonSequence(array $sequences, array $tokenTimestampSequences = null): array
+    private function findLongestCommonSequence(array $sequences, ?array $tokenTimestampSequences = null): array
     {
         $leftSequence = $sequences[0];
         $leftLength = count($leftSequence);
@@ -501,7 +501,7 @@ class WhisperTokenizer extends PreTrainedTokenizer
      */
     private function combineTokensIntoWords(
         array  $tokens,
-        string $language = null
+        ?string $language = null
     ): array
     {
         $language = $language ?? 'english';
@@ -522,7 +522,7 @@ class WhisperTokenizer extends PreTrainedTokenizer
         array $tokenIds,
         bool  $skipSpecialTokens = false,
         ?bool $cleanUpTokenizationSpaces = null,
-        bool  $decodeWithTimestamps = null,
+        ?bool $decodeWithTimestamps = null,
         float $timePrecision = 0.02
     ): string
     {

--- a/src/Tensor/MatrixOperator.php
+++ b/src/Tensor/MatrixOperator.php
@@ -10,7 +10,7 @@ use Rindow\Math\Matrix\NDArrayPhp;
 
 class MatrixOperator extends \Rindow\Math\Matrix\MatrixOperator
 {
-    protected function alloc(mixed $array, int $dtype = null, array $shape = null): NDArray
+    protected function alloc(mixed $array, ?int $dtype = null, ?array $shape = null): NDArray
     {
         if ($dtype === null) {
             //$dtype = $this->resolveDtype($array);

--- a/src/Tensor/Tensor.php
+++ b/src/Tensor/Tensor.php
@@ -61,10 +61,10 @@ class Tensor implements NDArray, Countable, Serializable, IteratorAggregate
     protected bool $portableSerializeMode = false;
 
     public function __construct(
-        mixed $array = null,
-        int   $dtype = null,
-        array $shape = null,
-        int   $offset = null,
+        mixed  $array = null,
+        ?int   $dtype = null,
+        ?array $shape = null,
+        ?int   $offset = null,
     ) {
         if ($array === null && $dtype === null && $shape === null && $offset === null) {
             // Empty definition for Unserialize

--- a/src/Tensor/TensorBuffer.php
+++ b/src/Tensor/TensorBuffer.php
@@ -22,7 +22,7 @@ class TensorBuffer implements LinearBuffer
     static protected ?FFI $ffi = null;
 
     /** @var array<int,string> $typeString */
-    protected static $typeString = [
+    protected static array $typeString = [
         NDArray::bool => 'uint8_t',
         NDArray::int8 => 'int8_t',
         NDArray::int16 => 'int16_t',
@@ -114,7 +114,7 @@ class TensorBuffer implements LinearBuffer
         }
     }
 
-    protected function isComplex(int $dtype = null): bool
+    protected function isComplex(?int $dtype = null): bool
     {
         $dtype = $dtype ?? $this->dtype;
         return $dtype == NDArray::complex64 || $dtype == NDArray::complex128;


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

adding nullable explicit to method parameters.

### Related:

https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated