### PR TITLE
fix: remove duplicate Transformers import

### DIFF
--- a/src/Pipelines/ZeroShotClassificationPipeline.php
+++ b/src/Pipelines/ZeroShotClassificationPipeline.php
@@ -10,7 +10,6 @@ use Codewithkyrian\Transformers\Models\Pretrained\PretrainedModel;
 use Codewithkyrian\Transformers\PreTrainedTokenizers\PreTrainedTokenizer;
 use Codewithkyrian\Transformers\Transformers;
 use Codewithkyrian\Transformers\Utils\Math;
-use Codewithkyrian\Transformers\Transformers;
 
 /**
  * NLI-based zero-shot classification pipeline using any model that has been fine-tuned on NLI (natural language inference)


### PR DESCRIPTION
Duplicate import causes ` Cannot use Codewithkyrian\Transformers\Transformers as Transformers because the name is already in use `

<!--
- Fill in the form below correctly. This will help the TransformersPHP team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

Fixes bug introduced here: https://github.com/CodeWithKyrian/transformers-php/commit/3b64b8856981a5bc4d9709bda941f2c6641040e9

### Related:

<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->
